### PR TITLE
Add missing `#` before immediate

### DIFF
--- a/examples/naive/aarch64/X25519-AArch64-simple.s
+++ b/examples/naive/aarch64/X25519-AArch64-simple.s
@@ -1470,7 +1470,7 @@ mainloop:
     lsr    x3, x2, #32
     subs   W<x0>, W<x2>, #1
     asr    W<x1>, W<x0>, #5
-    add    x4, sp, STACK_SCALAR
+    add    x4, sp, #STACK_SCALAR
     ldr    W<x1>, [x4, W<x1>, sxtw#2]
     and    W<x4>, W<x0>, #0x1f
     lsr    W<x1>, W<x1>, W<x4>


### PR DESCRIPTION
Previously the script in [scripts/nelight_x25519.sh](https://github.com/slothy-optimizer/slothy/blob/f4051970fc89bea7b1cf4bc9dba4eac6983a8dfb/scripts/nelight_x25519.sh) would fail with to the following parsing error:
`ERROR:root:Failed to parse instruction add    x4, sp, STACK_SCALAR`, where `STACK_SCALAR` is defined via `#define STACK_SCALAR  112` in [examples/naive/aarch64/X25519-AArch64-simple.s](https://github.com/slothy-optimizer/slothy/blob/f4051970fc89bea7b1cf4bc9dba4eac6983a8dfb/examples/naive/aarch64/X25519-AArch64-simple.s). 

The reason for the error is most likely a typo: [There](https://github.com/slothy-optimizer/slothy/blob/f4051970fc89bea7b1cf4bc9dba4eac6983a8dfb/examples/naive/aarch64/X25519-AArch64-simple.s#L1473C8-L1473C8) is a `#` missing before the `STACK_SCALAR`, which acts like an immediate upon its expansion. The parsing error disappears after adding the `#`.