### PR TITLE
Add config option for adding LLVM MCA based performance statistics

### DIFF
--- a/paper/scripts/slothy_dilithium_ntt_a55.sh
+++ b/paper/scripts/slothy_dilithium_ntt_a55.sh
@@ -34,7 +34,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c reserved_regs="[x0,x1,x2,x3,x4,x5,x6,v8,x30,sp]"                    \
          -c sw_pipelining.minimize_overlapping=False                            \
          -c constraints.stalls_first_attempt=110 -c variable_size               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 45678"
 
@@ -48,7 +48,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
          -c reserved_regs="[x3,x30,sp]"                                        \
          -c sw_pipelining.minimize_overlapping=False                           \
          -c constraints.stalls_first_attempt=40                                \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Dilithium NTT, Cortex-A55, 123-45678 (vector with scalar loads, without reduction)"
 echo "** Layer 123"
@@ -63,7 +63,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c reserved_regs="[x0,x1,x2,x3,x4,x5,x6,v8,x30,sp]"                            \
          -c sw_pipelining.minimize_overlapping=False                                    \
          -c constraints.stalls_first_attempt=110 -c variable_size                       \
-         $REDIRECT_OUTPUT                                                               \
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT                                                               \
 
 echo "** Layer 45678"
 
@@ -77,7 +77,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c reserved_regs="[x3,x30,sp]"                                                        \
          -c sw_pipelining.minimize_overlapping=False                                           \
          -c constraints.stalls_first_attempt=40                                                \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Dilithium NTT, Cortex-A55, 123-45678 (manual st4, without reduction)"
 echo "** Layer 123"
@@ -93,7 +93,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c sw_pipelining.minimize_overlapping=False                                       \
          -c constraints.stalls_first_attempt=110                                           \
          -c variable_size                                                                  \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 45678"
 
@@ -109,6 +109,6 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c split_heuristic                                                                        \
          -c split_heuristic_factor=2                                                               \
          -c constraints.stalls_first_attempt=40                                                    \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 cd "${0%/*}"

--- a/paper/scripts/slothy_dilithium_ntt_a72.sh
+++ b/paper/scripts/slothy_dilithium_ntt_a72.sh
@@ -35,7 +35,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend        \
           -c sw_pipelining.minimize_overlapping=False                    \
           -c constraints.stalls_first_attempt=110                        \
           -c variable_size                                               \
-          $REDIRECT_OUTPUT
+          $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 45678"
 
@@ -51,7 +51,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c split_heuristic                                             \
          -c split_heuristic_factor=2                                    \
          -c constraints.stalls_first_attempt=40                         \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Dilithium NTT, Cortex-A72, 123-45678 (manual st4, without reduction)"
 echo "** Layer 123"
@@ -67,7 +67,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c sw_pipelining.minimize_overlapping=False                    \
          -c constraints.stalls_first_attempt=110                        \
          -c variable_size                                               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 45678"
 
@@ -83,7 +83,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c split_heuristic                                             \
          -c split_heuristic_factor=2                                    \
          -c constraints.stalls_first_attempt=40                         \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Dilithium NTT, Cortex-A72, 1234-5678 (vector, without reduction)"
 echo "** Layer 1234"
@@ -104,7 +104,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c split_heuristic_stepsize=0.1                                \
          -c constraints.stalls_first_attempt=40                         \
          -c variable_size                                               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 5678"
 
@@ -118,4 +118,4 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c sw_pipelining.enabled=true                                  \
          -c constraints.stalls_first_attempt=40                         \
          -c variable_size                                               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT

--- a/paper/scripts/slothy_fft.sh
+++ b/paper/scripts/slothy_fft.sh
@@ -27,7 +27,7 @@ ${SLOTHY_DIR}/slothy-cli Arm_v81M Arm_Cortex_M55                        \
     -c constraints.functional_only=True                                 \
     -c visualize_reordering=False                                       \
     -o ${OPT_DIR}/helium/flt_r4_fft/base_ref.s                          \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 for uarch in M55 M85; do
     echo "* Floating point FFT, Cortex-${uarch}"
@@ -40,7 +40,7 @@ for uarch in M55 M85; do
         -c timeout=300                                                           \
         -r floatingpoint_radix4_fft_symbolic,floatingpoint_radix4_fft_opt_$uarch \
         -o ${OPT_DIR}/helium/flt_r4_fft/floatingpoint_radix4_fft_opt_$uarch.s    \
-        $REDIRECT_OUTPUT;
+        $SLOTHY_FLAGS $REDIRECT_OUTPUT;
 done
 
 # Fixed point FFT
@@ -53,7 +53,7 @@ ${SLOTHY_DIR}/slothy-cli Arm_v81M Arm_Cortex_M55                                
              -l fixedpoint_radix4_fft_loop_start                                 \
              -c visualize_reordering=False                                       \
              -o ${OPT_DIR}/helium/fx_r4_fft/base_concrete.s                      \
-             $REDIRECT_OUTPUT
+             $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 for uarch in M55 M85; do
     echo "* Fixed point FFT, Cortex-${uarch}"
@@ -67,5 +67,5 @@ for uarch in M55 M85; do
         -r fixedpoint_radix4_fft_symbolic,fixedpoint_radix4_fft_opt_$uarch \
         -c sw_pipelining.minimize_overlapping                              \
         -o ${OPT_DIR}/helium/fx_r4_fft/fixedpoint_radix4_fft_opt_$uarch.s  \
-        $REDIRECT_OUTPUT;
+        $SLOTHY_FLAGS $REDIRECT_OUTPUT;
 done

--- a/paper/scripts/slothy_kyber_ntt_a55.sh
+++ b/paper/scripts/slothy_kyber_ntt_a55.sh
@@ -33,7 +33,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55         \
          -c inputs_are_outputs                                   \
          -c sw_pipelining.minimize_overlapping=False             \
          -c constraints.stalls_first_attempt=64 -c variable_size \
-         ${REDIRECT_OUTPUT}
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A55, 123-4567 (vector loads via scalar, with reduction)"
 
@@ -49,7 +49,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c sw_pipelining.minimize_overlapping=False                                    \
          -c constraints.stalls_first_attempt=64                                         \
          -c variable_size                                                               \
-         ${REDIRECT_OUTPUT}
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A55, 123-4567 (vector stores via scalar, with reduction)"
 
@@ -65,7 +65,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
          -c inputs_are_outputs                                                          \
          -c constraints.stalls_first_attempt=64                                         \
          -c variable_size                                                               \
-         ${REDIRECT_OUTPUT}
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A55, 123-4567 (vector loads+stores via scalar, with reduction)"
 
@@ -80,7 +80,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
        -c inputs_are_outputs                                                                    \
        -c sw_pipelining.minimize_overlapping=False                                              \
        -c constraints.stalls_first_attempt=64 -c variable_size                                  \
-         ${REDIRECT_OUTPUT}
+       $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A55, 123-4567 (manual ST4, with reduction)"
 
@@ -95,6 +95,6 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                        
        -c inputs_are_outputs                                                    \
        -c sw_pipelining.minimize_overlapping=False                              \
        -c constraints.stalls_first_attempt=64 -c variable_size                  \
-         ${REDIRECT_OUTPUT}
+       $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 cd "${0%/*}"

--- a/paper/scripts/slothy_kyber_ntt_a72.sh
+++ b/paper/scripts/slothy_kyber_ntt_a72.sh
@@ -34,7 +34,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c inputs_are_outputs                                          \
          -c sw_pipelining.minimize_overlapping=False                    \
          -c constraints.stalls_first_attempt=64 -c variable_size        \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A72, 123-4567 (vector loads via scalar, with reduction)"
 
@@ -49,7 +49,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend               
          -c inputs_are_outputs                                                          \
          -c sw_pipelining.minimize_overlapping=False                                    \
          -c constraints.stalls_first_attempt=64 -c variable_size                        \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A72, 123-4567 (vector stores via scalar, with reduction)"
 
@@ -64,7 +64,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend               
          -c sw_pipelining.minimize_overlapping=False                                    \
          -c inputs_are_outputs                                                          \
          -c constraints.stalls_first_attempt=64 -c variable_size                        \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A72, 123-4567 (vector loads+stores via scalar, with reduction)"
 
@@ -79,7 +79,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend               
          -c inputs_are_outputs                                                                  \
          -c sw_pipelining.minimize_overlapping=False                                            \
          -c constraints.stalls_first_attempt=64 -c variable_size                                \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A72, 123-4567 (manual ST4, with reduction)"
 
@@ -94,7 +94,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend               
          -c inputs_are_outputs                                                  \
          -c sw_pipelining.minimize_overlapping=False                            \
          -c constraints.stalls_first_attempt=64 -c variable_size                \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "* Kyber NTT, Cortex-A72, 1234-567 (all vector, with reduction)"
 
@@ -116,7 +116,7 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c inputs_are_outputs                                          \
          -c sw_pipelining.minimize_overlapping=False                    \
          -c variable_size                                               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Layer 567"
 time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
@@ -131,4 +131,4 @@ time ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A72_frontend       \
          -c inputs_are_outputs                                          \
          -c sw_pipelining.minimize_overlapping=False                    \
          -c variable_size                                               \
-         $REDIRECT_OUTPUT
+         $SLOTHY_FLAGS $REDIRECT_OUTPUT

--- a/paper/scripts/slothy_ntt_helium.py
+++ b/paper/scripts/slothy_ntt_helium.py
@@ -96,6 +96,7 @@ class Example():
         logger = logging.getLogger(self.name)
         slothy = Slothy(self.arch, self.target, logger=logger)
         slothy.load_source_from_file(self.infile_full)
+        slothy.config.with_llvm_mca = True
         self.core(slothy, *self.extra_args)
 
         if self.rename:

--- a/paper/scripts/slothy_sqmag.sh
+++ b/paper/scripts/slothy_sqmag.sh
@@ -24,7 +24,7 @@ ${SLOTHY_DIR}/slothy-cli Arm_v81M Arm_Cortex_M55                    \
     -c constraints.allow_reordering=False                           \
     -o ${CLEAN_DIR}/helium/cmplx_mag_sqr/cmplx_mag_sqr_fx.s         \
     -c /visualize_reordering                                        \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 for uarch in M55 M85; do for i in 1 2 4; do
   echo "* Squared magnitude, Cortex-${uarch}, unroll x${i}"
@@ -37,7 +37,8 @@ for uarch in M55 M85; do for i in 1 2 4; do
       -c sw_pipelining.enabled=True                                                     \
       -c sw_pipelining.unroll=$i                                                        \
       -c constraints.stalls_first_attempt=1                                             \
+      -c with_llvm_mca                                                                  \
       -c timeout=$((10*$i))                                                             \
       -c /sw_pipelining.minimize_overlapping                                            \
-      -c variable_size $REDIRECT_OUTPUT ;
+      -c variable_size $SLOTHY_FLAGS $REDIRECT_OUTPUT ;
   done; done

--- a/paper/scripts/slothy_x25519.sh
+++ b/paper/scripts/slothy_x25519.sh
@@ -31,7 +31,7 @@ ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                          \
     -s mainloop -e end_label                                                 \
     -c constraints.allow_reordering=False                                    \
     -c constraints.functional_only=True                                      \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Step 1: Preprocessing"
 ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                          \
@@ -42,7 +42,7 @@ ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                          \
     -s mainloop -e end_label                                                 \
     -c split_heuristic -c split_heuristic_repeat=0                           \
     -c split_heuristic_preprocess_naive_interleaving                         \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "** Steps 2-6: Stepwise optimization, ignoring latencies"
 # The goal here is to get a good amount of interleaving
@@ -68,7 +68,7 @@ i=0
     -c split_heuristic_stepsize=0.1                                          \
     -c split_heuristic_factor=6                                              \
     -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "*** Step 3"
 i=1
@@ -89,7 +89,7 @@ i=1
     -c split_heuristic_stepsize=0.1                                          \
     -c split_heuristic_factor=4                                              \
     -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "*** Step 4"
 i=2
@@ -112,7 +112,7 @@ i=2
     -c split_heuristic_factor=6                                              \
     -c split_heuristic_repeat=1                                              \
     -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "*** Step 5"
 i=3
@@ -134,7 +134,7 @@ i=3
     -c split_heuristic_factor=6                                              \
     -c split_heuristic_repeat=1                                              \
     -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 # Finally, also consider latencies
 
@@ -157,7 +157,7 @@ i=4
     -c split_heuristic_optimize_seam=10                                      \
     -c split_heuristic_factor=8                                              \
     -c split_heuristic_repeat=1                                              \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "*** Step 7"
 i=5
@@ -180,7 +180,7 @@ i=5
     -c constraints.move_stalls_to_top                                        \
     -c split_heuristic_factor=8                                              \
     -c split_heuristic_repeat=2                                             \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 echo "*** Step 8"
 i=6
@@ -201,6 +201,6 @@ i=6
     -c split_heuristic_optimize_seam=10                                      \
     -c constraints.move_stalls_to_top                                        \
     -c split_heuristic_factor=8                                              \
-    $REDIRECT_OUTPUT
+    $SLOTHY_FLAGS $REDIRECT_OUTPUT
 
 cd "${0%/*}"

--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -297,11 +297,50 @@ class Config(NestedPrint, LockAttributes):
         return self._with_preprocessor
 
     @property
+    def with_llvm_mca(self):
+        """Indicates whether LLVM MCA should be run prior and after optimization
+        to obtain approximate performance data based on LLVM's scheduling models.
+
+        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
+        need to be set.
+        """
+        return self._with_llvm_mca_before and self._with_llvm_mca_after
+
+    @property
+    def with_llvm_mca_before(self):
+        """Indicates whether LLVM MCA should be run prior to optimization
+        to obtain approximate performance data based on LLVM's scheduling models.
+
+        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
+        need to be set.
+        """
+        return self._with_llvm_mca_before
+
+    @property
+    def with_llvm_mca_after(self):
+        """Indicates whether LLVM MCA should be run after optimization
+        to obtain approximate performance data based on LLVM's scheduling models.
+
+        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
+        need to be set.
+        """
+        return self._with_llvm_mca_after
+
+    @property
     def compiler_binary(self):
         """The compiler binary to be used.
 
-        This is only relevant of `with_preprocessor` is set."""
+        This is only relevant if `with_preprocessor` or `with_llvm_mca_before`
+        or `with_llvm_mca_after` are set."""
         return self._compiler_binary
+
+    @property
+    def llvm_mca_binary(self):
+        """The llvm-mca binary to be used for estimated performance annotations
+
+        This is only relevant if `with_llvm_mca_before` or `with_llvm_mca_after`
+        is set."""
+        return self._llvm_mca_binary
 
     @property
     def timeout(self):
@@ -982,6 +1021,7 @@ class Config(NestedPrint, LockAttributes):
         self._split_heuristic_preprocess_naive_interleaving_by_latency = False
 
         self._compiler_binary = "gcc"
+        self._llvm_mca_binary = "llvm-mca"
 
         self.keep_tags = True
         self.inherit_macro_comments = False
@@ -990,6 +1030,8 @@ class Config(NestedPrint, LockAttributes):
         self._do_address_fixup = True
 
         self._with_preprocessor = False
+        self._with_llvm_mca_before = False
+        self._with_llvm_mca_after = False
         self._max_solutions = 64
         self._timeout = None
         self._retry_timeout = None
@@ -1067,9 +1109,22 @@ class Config(NestedPrint, LockAttributes):
     @with_preprocessor.setter
     def with_preprocessor(self, val):
         self._with_preprocessor = val
+    @with_llvm_mca.setter
+    def with_llvm_mca(self, val):
+        self._with_llvm_mca_before = val
+        self._with_llvm_mca_after = val
+    @with_llvm_mca_after.setter
+    def with_llvm_mca_after(self, val):
+        self._with_llvm_mca_after = val
+    @with_llvm_mca_before.setter
+    def with_llvm_mca_before(self, val):
+        self._with_llvm_mca_before = val
     @compiler_binary.setter
     def compiler_binary(self, val):
         self._compiler_binary = val
+    @llvm_mca_binary.setter
+    def llvm_mca_binary(self, val):
+        self._llvm_mca_binary = val
     @timeout.setter
     def timeout(self, val):
         self._timeout = val

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -1586,7 +1586,7 @@ class SlothyBase(LockAttributes):
     def _extract_kernel_input_output(self):
         dfg_log = self.logger.getChild("kernel_input_output")
         self._result.kernel_input_output = list(\
-            DFG(self._result.code, dfg_log,
+            DFG(self._result.code_raw, dfg_log,
                 DFGConfig(self.config,inputs_are_outputs=True)).inputs)
 
     def _extract_code(self):

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -46,6 +46,8 @@ from functools import cache
 
 from sympy import simplify
 
+llvm_mca_arch = "aarch64"
+
 class RegisterType(Enum):
     GPR = 1
     NEON = 2

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -45,6 +45,7 @@ from enum import Enum
 from slothy.targets.aarch64.aarch64_neon import *
 
 issue_rate = 2
+llvm_mca_target = "cortex-a55"
 
 class ExecutionUnit(Enum):
     """Enumeration of execution units in Cortex-A55 model"""

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -59,6 +59,7 @@ from .aarch64_neon import *
 # modelling the frontend, not the backend, but `issue_width` is
 # what SLOTHY expects.
 issue_rate = 3
+llvm_mca_target = "cortex-a72"
 
 class ExecutionUnit(Enum):
     """Enumeration of execution units in approximative Cortex-A72 SLOTHY model"""

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -40,6 +40,8 @@ import math
 from sympy import simplify
 from enum import Enum
 
+llvm_mca_arch = "arm"
+
 class RegisterType(Enum):
     GPR = 1,
     MVE = 2,

--- a/slothy/targets/arm_v81m/cortex_m55r1.py
+++ b/slothy/targets/arm_v81m/cortex_m55r1.py
@@ -40,6 +40,7 @@ from enum import Enum
 from slothy.targets.arm_v81m.arch_v81m import *
 
 issue_rate = 1
+llvm_mca_target = "cortex-m55"
 
 class ExecutionUnit(Enum):
     SCALAR=0,

--- a/slothy/targets/arm_v81m/cortex_m85r1.py
+++ b/slothy/targets/arm_v81m/cortex_m85r1.py
@@ -40,6 +40,7 @@ from enum import Enum
 from slothy.targets.arm_v81m.arch_v81m import *
 
 issue_rate = 1
+llvm_mca_target = "cortex-m85"
 
 class ExecutionUnit(Enum):
     SCALAR=0,


### PR DESCRIPTION
When optimizing for Cortex-M55, Cortex-M85, Cortex-A55 or Cortex-A72, the option `-c with_llvm_mca` will run LLVM MCA (Machine Code Analyzer) on the original and optimized source code and emit the estimated performance characteristics as comments in the generated source file.

This is useful to get an indicator of the quality of the performance improvements even without dedicated hardware.

To test, build llvm from source, https://github.com/llvm/llvm-project (you need a very recent version since `llvm-mca` was only added to the default build in Nov'23) and make sure `llvm-mca` is in your `PATH`.

`-c with_llvm_mca` can be passed to the various scripts in `paper/` via `SLOTHY_FLAGS="-c with_llvm_mca"`.

NOTE, though, that the LLVM MCA scheduling models are approximative as well. Moreover, they seem partly too pessimistic: E.g., on M85 many stalls are predicted for uses of VCMLA,VST4,VLD4, which I don't think is correct.