### PR TITLE
Fix examples

### DIFF
--- a/example.py
+++ b/example.py
@@ -426,16 +426,6 @@ class ntt_kyber_345(Example):
         slothy.optimize_loop("layer345_loop")
 
 
-class ntt_kyber_l345_symbolic(Example):
-    def __init__(self):
-        super().__init__("ntt_kyber_layer345_symbolic")
-    def core(self,slothy):
-        slothy.config.sw_pipelining.enabled = True
-        slothy.config.sw_pipelining.halving_heuristic = True
-        slothy.config.sw_pipelining.halving_heuristic_periodic = True
-        slothy.optimize_loop("layer345_loop")
-
-
 class ntt_kyber_123_4567(Example):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
         name = "ntt_kyber_123_4567"
@@ -795,29 +785,6 @@ class ntt_dilithium_123_456_78(Example):
             slothy.config.outputs = slothy.last_result.kernel_input_output + ["r14"]
             slothy.optimize(start="layer456_loop_end", end="layer78_loop")
 
-
-class ntt_dilithium_123_456_78_symbolic(Example):
-    def __init__(self):
-        super().__init__("ntt_dilithium_123_456_78_symbolic", rename=True)
-    def core(self,slothy):
-        slothy.config.typing_hints = {
-            "root2"         : Arch_Armv81M.RegisterType.GPR,
-            "root3"         : Arch_Armv81M.RegisterType.GPR,
-            "root5"         : Arch_Armv81M.RegisterType.GPR,
-            "root6"         : Arch_Armv81M.RegisterType.GPR,
-            "rtmp"          : Arch_Armv81M.RegisterType.GPR,
-            "rtmp_tw"       : Arch_Armv81M.RegisterType.GPR,
-            "root2_tw"      : Arch_Armv81M.RegisterType.GPR,
-            "root3_tw"      : Arch_Armv81M.RegisterType.GPR,
-            "root5_tw"      : Arch_Armv81M.RegisterType.GPR,
-            "root6_tw"      : Arch_Armv81M.RegisterType.GPR,
-        }
-        slothy.config.sw_pipelining.enabled=True
-        slothy.config.constraints.stalls_minimum_attempt = 0
-        slothy.config.constraints.stalls_first_attempt = 0
-        slothy.config.locked_registers = set( [ f"QSTACK{i}" for i in [4,5,6] ] +
-                                               [ "ROOT0_STACK", "RPTR_STACK" ] )
-        slothy.optimize_loop("layer456_loop")
 
 class ntt_dilithium_123_45678(Example):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):

--- a/examples/naive/aarch64/X25519-AArch64-simple.s
+++ b/examples/naive/aarch64/X25519-AArch64-simple.s
@@ -113,7 +113,7 @@
 .endm
 
 # TODO: also unwrap
-.macro fcsel_dform out, in0, in1, cond // slothy:no-unfold
+.macro fcsel_dform out, in0, in1, cond // @slothy:no-unfold
   fcsel dform_\out, dform_\in0, dform_\in1, \cond
 .endm
 

--- a/examples/naive/aarch64/intt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/intt_dilithium_1234_5678.s
@@ -177,7 +177,7 @@
         trn1_d \data\()1, t1, t3
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -188,7 +188,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -198,7 +198,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -206,7 +206,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -217,19 +217,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/ntt_dilithium_1234_5678.s
@@ -137,7 +137,7 @@
         trn1 \data\()1\().2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -148,7 +148,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -158,7 +158,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -166,7 +166,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -177,19 +177,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_1234_5678_manual_st4.s
+++ b/examples/naive/aarch64/ntt_dilithium_1234_5678_manual_st4.s
@@ -143,7 +143,7 @@
         trn1 \data1\().2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -154,7 +154,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -164,7 +164,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -172,7 +172,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -183,19 +183,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678.s
@@ -186,7 +186,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -197,7 +197,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -215,7 +215,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -226,19 +226,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_manual_st4.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_manual_st4.s
@@ -186,7 +186,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -197,7 +197,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -215,7 +215,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -226,19 +226,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_red.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_red.s
@@ -154,7 +154,7 @@
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -165,7 +165,7 @@
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -175,7 +175,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -183,7 +183,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -194,19 +194,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar.s
@@ -196,7 +196,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -217,7 +217,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -225,7 +225,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -236,19 +236,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar_red.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar_red.s
@@ -185,7 +185,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -196,7 +196,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -206,7 +206,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -214,7 +214,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -225,19 +225,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_1234_567.s
+++ b/examples/naive/aarch64/ntt_kyber_1234_567.s
@@ -138,7 +138,7 @@
         trn1 \data\()1\().2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -149,7 +149,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -159,7 +159,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -167,7 +167,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -178,19 +178,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_1234_567_manual_st4.s
+++ b/examples/naive/aarch64/ntt_kyber_1234_567_manual_st4.s
@@ -146,7 +146,7 @@
         str_vo \a3, \addr, (-(\inc) + 16*3)
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -157,7 +157,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -167,7 +167,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -175,7 +175,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -186,19 +186,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567.s
@@ -139,7 +139,7 @@
         trn2 \data_out\()3\().4s, \data_in\()2\().4s, \data_in\()3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -150,7 +150,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -160,7 +160,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -168,7 +168,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -179,19 +179,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_manual_st4.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_manual_st4.s
@@ -146,7 +146,7 @@
         trn2 \data_out\()3\().4s, \data_in\()2\().4s, \data_in\()3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -157,7 +157,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -167,7 +167,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -175,7 +175,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -186,19 +186,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load.s
@@ -151,7 +151,7 @@ xtmp1 .req x11
         trn2 \data_out\()3\().4s, \data_in\()2\().4s, \data_in\()3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -162,7 +162,7 @@ xtmp1 .req x11
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -172,7 +172,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -180,7 +180,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -191,19 +191,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load_store.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load_store.s
@@ -178,7 +178,7 @@ xtmp1 .req x11
 .endm
 
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -189,7 +189,7 @@ xtmp1 .req x11
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -199,7 +199,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -218,19 +218,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_store.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_store.s
@@ -165,7 +165,7 @@
 .endm
 
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -176,7 +176,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -186,7 +186,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -194,7 +194,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -205,19 +205,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/ntt_dilithium_123_456_78.s
+++ b/examples/naive/ntt_dilithium_123_456_78.s
@@ -42,27 +42,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @@slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @@slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @@slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @@slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @@slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @@slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @@slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -71,7 +71,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @@slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_dilithium_123_456_78_symbolic.s
+++ b/examples/naive/ntt_dilithium_123_456_78_symbolic.s
@@ -44,27 +44,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -73,7 +73,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_dilithium_123_456_78_trans.s
+++ b/examples/naive/ntt_dilithium_123_456_78_trans.s
@@ -42,27 +42,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -71,7 +71,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_kyber_12_345_67.s
+++ b/examples/naive/ntt_kyber_12_345_67.s
@@ -44,22 +44,22 @@ roots:
 
 #define STACK_SIZE (3*16 + 8)
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
@@ -77,7 +77,7 @@ roots:
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC
         sub sp, sp, r12      // Align stack to 16 byte
@@ -86,7 +86,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_kyber_12_345_67_trans.s
+++ b/examples/naive/ntt_kyber_12_345_67_trans.s
@@ -44,22 +44,22 @@ roots:
 
 #define STACK_SIZE (3*16 + 8)
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
@@ -77,7 +77,7 @@ roots:
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC
         sub sp, sp, r12      // Align stack to 16 byte
@@ -86,7 +86,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -33,11 +33,19 @@ class SourceLine:
     """Representation of a single line of source code"""
 
     def _extract_comments_from_text(self):
-        if not "//" in self._raw:
+        # Match // and /* ... */ style comments with optionally preceeding code
+        match = re.search(
+            r"(?P<code>.*?)\s*(//|/\*)\s*(?P<comment>.*?)\s*(?:\*/|$)",
+            self._raw)
+
+        # Check if there are any comments
+        if not match:
             return
-        s = list(map(str.strip, self._raw.split("//")))
-        self._raw = s[0]
-        self._comments += s[1:]
+
+        comment = match.group("comment")
+
+        self._raw = match.group("code")
+        self._comments.append(comment)
         self._trim_comments()
 
     def _extract_indentation_from_text(self):

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -222,7 +222,9 @@ class SourceLine:
         assert SourceLine.is_source(src)
         for l in src:
             l.reduce()
-        return [ l for l in src if l.has_text() and not AsmHelper.is_alignment_directive(l) ]
+        return [ l for l in src if l.has_text() and
+                 not AsmHelper.is_alignment_directive(l) and
+                 not AsmHelper.is_allocation_directive(l) ]
 
     @staticmethod
     def log(name, s, logger=None, err=False):
@@ -479,6 +481,13 @@ class AsmHelper():
         """Checks is source line is an alignment directive `.[p2]align _`"""
         assert SourceLine.is_source_line(line)
         return AsmHelper._REGEXP_ALIGN.match(line.text) is not None
+
+    @staticmethod
+    def is_allocation_directive(line):
+        """Checks is source line is an allocation directive. """
+        assert SourceLine.is_source_line(line)
+        return (AsmAllocation.is_allocation(line) or
+                AsmAllocation.is_deallocation(line))
 
     @staticmethod
     def extract(source, lbl_start=None, lbl_end=None):


### PR DESCRIPTION
- Allow for `/* ... */`-style single-line comments
- Remove `.req` and `.unreq` directives from source when optimizing "seams" between loops
- Add missing `@` for `slothy:no-unfold` tags
- Remove symbolic NTT examples from `example.py`