### PR TITLE
Fix x25519 example and improve efficiency

### DIFF
--- a/paper/clean/neon/X25519-AArch64-simple.s
+++ b/paper/clean/neon/X25519-AArch64-simple.s
@@ -27,6 +27,7 @@
  */
 
 #include <hal_env.h>
+#include "instruction_wrappers.i"
 
 #define STACK_MASK1     0
 #define STACK_MASK2     8

--- a/paper/clean/neon/X25519-AArch64-simple.s
+++ b/paper/clean/neon/X25519-AArch64-simple.s
@@ -19,7 +19,14 @@
  * and no conditional branches or memory access pattern depend on secret data.
  */
 
-//#include <hal_env.h>
+/*
+ * Implementation manually de-interleaved and modularized for use with SLOTHY. See
+ *
+ *   Fast and Clean: Auditable High Performance Assembly via Constraint Solving
+ *   (Abdulrahman, Becker, Kannwischer, Klein)
+ */
+
+#include <hal_env.h>
 
 #define STACK_MASK1     0
 #define STACK_MASK2     8

--- a/paper/clean/neon/X25519-AArch64-simple.s
+++ b/paper/clean/neon/X25519-AArch64-simple.s
@@ -29,6 +29,10 @@
 #include <hal_env.h>
 #include "instruction_wrappers.i"
 
+.macro fcsel_dform out, in0, in1, cond // @slothy:no-unfold
+  fcsel dform_\out, dform_\in0, dform_\in1, \cond
+.endm
+
 #define STACK_MASK1     0
 #define STACK_MASK2     8
 #define STACK_A_0      16

--- a/paper/scripts/slothy_x25519.sh
+++ b/paper/scripts/slothy_x25519.sh
@@ -107,16 +107,39 @@ i=2
     -c split_heuristic_region="[0.3,1]"                                      \
     -c objective_precision=0.1                                               \
     -c constraints.move_stalls_to_top                                        \
-    -c split_heuristic_stepsize=0.08                                         \
+    -c split_heuristic_bottom_to_top                                         \
+    -c split_heuristic_stepsize=0.2                                          \
     -c split_heuristic_factor=6                                              \
-    -c split_heuristic_repeat=3                                              \
+    -c split_heuristic_repeat=1                                              \
+    -c constraints.model_latencies=False                                     \
+    $REDIRECT_OUTPUT
+
+echo "*** Step 5"
+i=3
+    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                      \
+       ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
+    -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
+    -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_alt_unfold_process$((${i}+1)) \
+    -c inputs_are_outputs -c outputs="[x0]"                                  \
+    -s mainloop -e end_label                                                 \
+    -c variable_size                                                         \
+    -c max_solutions=512                                                     \
+    -c timeout=240                                                           \
+    -c constraints.stalls_first_attempt=32                                   \
+    -c split_heuristic                                                       \
+    -c split_heuristic_region="[0.3,1]"                                      \
+    -c objective_precision=0.1                                               \
+    -c constraints.move_stalls_to_top                                        \
+    -c split_heuristic_stepsize=0.2                                          \
+    -c split_heuristic_factor=6                                              \
+    -c split_heuristic_repeat=1                                              \
     -c constraints.model_latencies=False                                     \
     $REDIRECT_OUTPUT
 
 # Finally, also consider latencies
 
-echo "*** Step 5"
-i=3
+echo "*** Step 6"
+i=4
    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
        ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
     -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
@@ -136,8 +159,8 @@ i=3
     -c split_heuristic_repeat=1                                              \
     $REDIRECT_OUTPUT
 
-echo "*** Step 6"
-i=4
+echo "*** Step 7"
+i=5
    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
        ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
     -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
@@ -159,8 +182,8 @@ i=4
     -c split_heuristic_repeat=2                                             \
     $REDIRECT_OUTPUT
 
-echo "*** Step 7"
-i=5
+echo "*** Step 8"
+i=6
    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
        ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
     -o ${OPT_DIR}/neon/X25519-AArch64-simple_opt.s                           \

--- a/paper/scripts/slothy_x25519.sh
+++ b/paper/scripts/slothy_x25519.sh
@@ -113,57 +113,10 @@ i=2
     -c constraints.model_latencies=False                                     \
     $REDIRECT_OUTPUT
 
-echo "*** Step 5"
-i=3
-    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                      \
-       ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
-    -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
-    -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_alt_unfold_process$((${i}+1)) \
-    -c inputs_are_outputs -c outputs="[x0]"                                  \
-    -s mainloop -e end_label                                                 \
-    -c variable_size                                                         \
-    -c max_solutions=512                                                     \
-    -c timeout=240                                                           \
-    -c constraints.stalls_first_attempt=32                                   \
-    -c split_heuristic                                                       \
-    -c split_heuristic_region="[0.3,1]"                                      \
-    -c objective_precision=0.1                                               \
-    -c constraints.move_stalls_to_top                                        \
-    -c split_heuristic_stepsize=0.05                                         \
-    -c split_heuristic_factor=5                                              \
-    -c split_heuristic_repeat=3                                              \
-    -c split_heuristic_abort_cycle_at=8                                      \
-    -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
-
-echo "*** Step 6"
-i=4
-    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                      \
-       ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
-    -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
-    -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_alt_unfold_process$((${i}+1)) \
-    -c inputs_are_outputs -c outputs="[x0]"                                  \
-    -s mainloop -e end_label                                                 \
-    -c variable_size                                                         \
-    -c max_solutions=512                                                     \
-    -c timeout=180                                                           \
-    -c constraints.stalls_first_attempt=32                                   \
-    -c split_heuristic                                                       \
-    -c split_heuristic_region="[0.2,1]"                                      \
-    -c objective_precision=0.1                                               \
-    -c constraints.move_stalls_to_top                                        \
-    -c split_heuristic_stepsize=0.05                                         \
-    -c split_heuristic_factor=5                                              \
-    -c split_heuristic_repeat=3                                              \
-    -c split_heuristic_abort_cycle_at=5                                      \
-    -c constraints.model_latencies=False                                     \
-    $REDIRECT_OUTPUT
-
 # Finally, also consider latencies
 
-echo "** Step 7-9: Consider latencies"
-echo "*** Step 7"
-i=5
+echo "*** Step 5"
+i=3
    ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
        ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
     -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
@@ -180,50 +133,51 @@ i=5
     -c split_heuristic_stepsize=0.05                                         \
     -c split_heuristic_optimize_seam=10                                      \
     -c split_heuristic_factor=8                                              \
-    -c split_heuristic_repeat=10                                             \
+    -c split_heuristic_repeat=1                                              \
     $REDIRECT_OUTPUT
 
-echo "*** Step 8"
-i=6
-  ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
-      ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s         \
-   -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s  \
-   -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_alt_unfold_process$((${i}+1)) \
-   -c inputs_are_outputs -c outputs="[x0]"                                  \
-   -s mainloop -e end_label                                                 \
-   -c variable_size                                                         \
-   -c max_solutions=512                                                     \
-   -c timeout=300                                                           \
-   -c constraints.stalls_first_attempt=32                                   \
-   -c split_heuristic                                                       \
-   -c split_heuristic_region="[0,1]"                                        \
-   -c objective_precision=0.1                                               \
-   -c split_heuristic_stepsize=0.05                                         \
-   -c split_heuristic_optimize_seam=10                                      \
-   -c split_heuristic_factor=8                                              \
-   -c split_heuristic_repeat=3                                              \
+echo "*** Step 6"
+i=4
+   ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
+       ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
+    -o ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process$((${i}+1)).s     \
+    -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_alt_unfold_process$((${i}+1)) \
+    -c inputs_are_outputs -c outputs="[x0]"                                  \
+    -s mainloop -e end_label                                                 \
+    -c variable_size                                                         \
+    -c max_solutions=512                                                     \
+    -c timeout=300                                                           \
+    -c constraints.stalls_first_attempt=32                                   \
+    -c split_heuristic                                                       \
+    -c split_heuristic_region="[0,1]"                                        \
+    -c split_heuristic_bottom_to_top=True                                    \
+    -c objective_precision=0.1                                               \
+    -c split_heuristic_stepsize=0.05                                         \
+    -c split_heuristic_optimize_seam=10                                      \
+    -c constraints.move_stalls_to_top                                        \
+    -c split_heuristic_factor=8                                              \
+    -c split_heuristic_repeat=2                                             \
     $REDIRECT_OUTPUT
 
-echo "*** Step 9"
-i=7
-  ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
-      ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s         \
-   -o ${OPT_DIR}/neon/X25519-AArch64-simple_opt.s                           \
-   -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_opt     \
-   -c inputs_are_outputs -c outputs="[x0]"                                  \
-   -s mainloop -e end_label                                                 \
-   -c variable_size                                                         \
-   -c max_solutions=512                                                     \
-   -c timeout=300                                                           \
-   -c constraints.stalls_first_attempt=32                                   \
-   -c split_heuristic                                                       \
-   -c split_heuristic_region="[0,1]"                                        \
-   -c objective_precision=0.1                                               \
-   -c split_heuristic_stepsize=0.05                                         \
-   -c split_heuristic_optimize_seam=10                                      \
-   -c split_heuristic_factor=8                                              \
-   -c split_heuristic_repeat=3                                              \
-   -c constraints.move_stalls_to_top                                        \
+echo "*** Step 7"
+i=5
+   ${SLOTHY_DIR}/slothy-cli Arm_AArch64 Arm_Cortex_A55                       \
+       ${OPT_DIR}/neon/X25519-AArch64-simple_unfold_process${i}.s            \
+    -o ${OPT_DIR}/neon/X25519-AArch64-simple_opt.s                           \
+    -r x25519_scalarmult_alt_unfold_process${i},x25519_scalarmult_opt        \
+    -c inputs_are_outputs -c outputs="[x0]"                                  \
+    -s mainloop -e end_label                                                 \
+    -c variable_size                                                         \
+    -c max_solutions=512                                                     \
+    -c timeout=300                                                           \
+    -c constraints.stalls_first_attempt=32                                   \
+    -c split_heuristic                                                       \
+    -c split_heuristic_region="[0,1]"                                        \
+    -c objective_precision=0.1                                               \
+    -c split_heuristic_stepsize=0.05                                         \
+    -c split_heuristic_optimize_seam=10                                      \
+    -c constraints.move_stalls_to_top                                        \
+    -c split_heuristic_factor=8                                              \
     $REDIRECT_OUTPUT
 
 cd "${0%/*}"

--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -399,13 +399,22 @@ class Config(NestedPrint, LockAttributes):
         return self._split_heuristic_factor
 
     @property
-    def split_heuristic_abort_cycle_at(self):
+    def split_heuristic_abort_cycle_at_high(self):
         """During the split heuristic, a threshold for the number of stalls in the current
         optimization window above which the current pass of the split heuristic should stop."""
         if not self.split_heuristic:
             raise InvalidConfig("Did you forget to set config.split_heuristic=True? "\
                             "Shouldn't read config.split_heuristic_abort_cycle_at otherwise.")
-        return self._split_heuristic_abort_cycle_at
+        return self._split_heuristic_abort_cycle_at_high
+
+    @property
+    def split_heuristic_abort_cycle_at_low(self):
+        """During the split heuristic, a threshold for the number of stalls in the current
+        optimization window below which the current pass of the split heuristic should stop."""
+        if not self.split_heuristic:
+            raise InvalidConfig("Did you forget to set config.split_heuristic=True? "\
+                            "Shouldn't read config.split_heuristic_abort_cycle_at otherwise.")
+        return self._split_heuristic_abort_cycle_at_low
 
     @property
     def split_heuristic_stepsize(self):
@@ -965,7 +974,8 @@ class Config(NestedPrint, LockAttributes):
         self._split_heuristic_optimize_seam = 0
         self._split_heuristic_bottom_to_top = False
         self._split_heuristic_factor = 2
-        self._split_heuristic_abort_cycle_at = None
+        self._split_heuristic_abort_cycle_at_high = None
+        self._split_heuristic_abort_cycle_at_low = None
         self._split_heuristic_stepsize = None
         self._split_heuristic_repeat = 1
         self._split_heuristic_preprocess_naive_interleaving = False
@@ -1090,9 +1100,12 @@ class Config(NestedPrint, LockAttributes):
     @split_heuristic_factor.setter
     def split_heuristic_factor(self, val):
         self._split_heuristic_factor = float(val)
-    @split_heuristic_abort_cycle_at.setter
-    def split_heuristic_abort_cycle_at(self, val):
-        self._split_heuristic_abort_cycle_at = val
+    @split_heuristic_abort_cycle_at_high.setter
+    def split_heuristic_abort_cycle_at_high(self, val):
+        self._split_heuristic_abort_cycle_at_high = val
+    @split_heuristic_abort_cycle_at_low.setter
+    def split_heuristic_abort_cycle_at_low(self, val):
+        self._split_heuristic_abort_cycle_at_low = val
     @split_heuristic_stepsize.setter
     def split_heuristic_stepsize(self, val):
         self._split_heuristic_stepsize = float(val)

--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -674,14 +674,18 @@ class Heuristics():
 
             return new_body, new_stalls, len(result.stall_positions), perm
 
-        def optimize_chunks_many(start_end_idx_lst, body, stalls, abort_stall_threshold=None,
-            **kwargs):
+        def optimize_chunks_many(start_end_idx_lst, body, stalls,
+                                 abort_stall_threshold_high=None,
+                                 abort_stall_threshold_low=None,
+                                 **kwargs):
             perm = Permutation.permutation_id(len(body))
             for start_idx, end_idx in start_end_idx_lst:
                 body, stalls, cur_stalls, local_perm = optimize_chunk(start_idx, end_idx, body,
                                                                       stalls, **kwargs)
                 perm = Permutation.permutation_comp(local_perm, perm)
-                if abort_stall_threshold is not None and cur_stalls > abort_stall_threshold:
+                if abort_stall_threshold_high is not None and cur_stalls > abort_stall_threshold_high:
+                    break
+                if abort_stall_threshold_low is not None and cur_stalls < abort_stall_threshold_low:
                     break
             return body, stalls, perm
 
@@ -750,7 +754,8 @@ class Heuristics():
                     idx_lst.reverse()
 
             cur_body, stalls, local_perm = optimize_chunks_many(idx_lst, cur_body, stalls,
-                                    abort_stall_threshold=conf.split_heuristic_abort_cycle_at)
+                               abort_stall_threshold_high=conf.split_heuristic_abort_cycle_at_high,
+                               abort_stall_threshold_low=conf.split_heuristic_abort_cycle_at_low)
             perm = Permutation.permutation_comp(local_perm, perm)
 
         # Check complete result

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -323,6 +323,7 @@ class Instruction:
         self.addr = None
         self.increment = None
         self.pre_index = None
+        self.offset_adjustable = True
 
         self.immediate = None
         self.datatype = None
@@ -432,10 +433,11 @@ class Instruction:
 
     def is_vector_load(self):
         """Indicates if an instruction is a Neon load instruction"""
-        return self._is_instance_of([ Ldr_Q, Ldp_Q ]) # TODO: Ld4 missing?
+        return self._is_instance_of([ Ldr_Q, Ldp_Q, Ld2, Ld4, Q_Ld2_Lane_Post_Inc ])
     def is_vector_store(self):
         """Indicates if an instruction is a Neon store instruction"""
-        return self._is_instance_of([ Str_Q, Stp_Q, St4, d_stp_stack_with_inc, d_str_stack_with_inc])
+        return self._is_instance_of([ Str_Q, Stp_Q, St2, St4,
+                                      d_stp_stack_with_inc, d_str_stack_with_inc])
 
     # scalar
     def is_scalar_load(self):
@@ -2710,6 +2712,7 @@ class st4_base(St4): # pylint: disable=missing-docstring,invalid-name
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
+        obj.offset_adjustable = False
         obj.addr = obj.args_in[0]
         obj.args_in_combinations = [
                 ( [1,2,3,4], [ [ f"v{i}", f"v{i+1}", f"v{i+2}", f"v{i+3}" ] for i in range(0,28) ] )
@@ -2739,6 +2742,7 @@ class st2_base(St2): # pylint: disable=missing-docstring,invalid-name
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
+        obj.offset_adjustable = False
         obj.addr = obj.args_in[0]
         obj.args_in_combinations = [
                 ( [1,2], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
@@ -2769,6 +2773,7 @@ class ld4_base(Ld4): # pylint: disable=missing-docstring,invalid-name
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
+        obj.offset_adjustable = False
         obj.addr = obj.args_in[0]
         obj.args_out_combinations = [
                 ( [0,1,2,3], [ [ f"v{i}", f"v{i+1}", f"v{i+2}", f"v{i+3}" ] for i in range(0,28) ] )
@@ -2800,6 +2805,7 @@ class ld2_base(Ld2): # pylint: disable=missing-docstring,invalid-name
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
+        obj.offset_adjustable = False
         obj.addr = obj.args_in[0]
         obj.args_out_combinations = [
                 ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -990,6 +990,9 @@ class q_ld2_lane_post_inc(Q_Ld2_Lane_Post_Inc): # pylint: disable=missing-docstr
         obj.pre_index = None
         obj.addr = obj.args_in[0]
         obj.detected_q_ld2_lane_post_inc_pair = False
+        obj.args_in_out_combinations = [
+                ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+            ]
         return obj
 
     def write(self):
@@ -1009,6 +1012,9 @@ class q_ld2_lane_post_inc_force_output(Q_Ld2_Lane_Post_Inc): # pylint: disable=m
         obj.increment = obj.immediate
         obj.pre_index = None
         obj.addr = obj.args_in[0]
+        obj.args_out_combinations = [
+                ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+            ]
         return obj
 
     def write(self):
@@ -2735,7 +2741,7 @@ class st2_base(St2): # pylint: disable=missing-docstring,invalid-name
         obj = AArch64Instruction.build(cls, src)
         obj.addr = obj.args_in[0]
         obj.args_in_combinations = [
-                ( [1,2,3,4], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+                ( [1,2], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
             ]
         return obj
 
@@ -2749,7 +2755,7 @@ class st2_with_inc(St2): # pylint: disable=missing-docstring,invalid-name
         obj.increment = obj.immediate
         obj.pre_index = None
         obj.args_in_combinations = [
-                ( [1,2,3,4], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+                ( [1,2], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
             ]
         return obj
 
@@ -2796,7 +2802,7 @@ class ld2_base(Ld2): # pylint: disable=missing-docstring,invalid-name
         obj = AArch64Instruction.build(cls, src)
         obj.addr = obj.args_in[0]
         obj.args_out_combinations = [
-                ( [0,1,2,3], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+                ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
             ]
         return obj
 
@@ -2811,9 +2817,8 @@ class ld2_with_inc(Ld2): # pylint: disable=missing-docstring,invalid-name
         obj.increment = obj.immediate
         obj.pre_index = None
         obj.args_out_combinations = [
-                ( [0,1,2,3], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
+                ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
             ]
-
         return obj
 
 # In a pair of vins writing both 64-bit lanes of a vector, mark the

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -51,9 +51,8 @@ class RegisterType(Enum):
     NEON = 2
     STACK_NEON = 3
     STACK_GPR = 4
-    STACK_ANY = 5
-    FLAGS = 6
-    HINT = 7
+    FLAGS = 5
+    HINT = 6
 
     def __str__(self):
         return self.name
@@ -67,33 +66,6 @@ class RegisterType(Enum):
 
         qstack_locations = [ f"QSTACK{i}" for i in range(8) ]
         stack_locations  = [ f"STACK{i}"  for i in range(8) ]
-
-        # TODO: this is needed for X25519; as we use the same stack space
-        # for Neon and GPR; It would be great to unify. Ideally, one should
-        # be able to just use STACK_ without having to define it here
-        stack_any_locations = [
-            "STACK_MASK1",
-            "STACK_MASK2",
-            "STACK_A_0",
-            "STACK_A_8",
-            "STACK_A_16",
-            "STACK_A_24",
-            "STACK_A_32",
-            "STACK_B_0",
-            "STACK_B_8",
-            "STACK_B_16",
-            "STACK_B_24",
-            "STACK_B_32",
-            "STACK_CTR",
-            "STACK_LASTBIT",
-            "STACK_SCALAR",
-            "STACK_X_0",
-            "STACK_X_8",
-            "STACK_X_16",
-            "STACK_X_24",
-            "STACK_X_32"
-        ]
-
 
         gprs_normal  = [ f"x{i}" for i in range(31) ] + ["sp"]
         vregs_normal = [ f"v{i}" for i in range(32) ]
@@ -124,7 +96,6 @@ class RegisterType(Enum):
         return { RegisterType.GPR      : gprs,
                  RegisterType.STACK_GPR : stack_locations,
                  RegisterType.STACK_NEON : qstack_locations,
-                 RegisterType.STACK_ANY  : stack_any_locations,
                  RegisterType.NEON      : vregs,
                  RegisterType.HINT      : hints,
                  RegisterType.FLAGS     : flags}[reg_type]
@@ -155,7 +126,6 @@ class RegisterType(Enum):
         string = string.lower()
         return { "qstack"    : RegisterType.STACK_NEON,
                  "stack"     : RegisterType.STACK_GPR,
-                 "stack_any" : RegisterType.STACK_ANY,
                  "neon"      : RegisterType.NEON,
                  "gpr"       : RegisterType.GPR,
                  "hint"      : RegisterType.HINT,
@@ -164,28 +134,7 @@ class RegisterType(Enum):
     @staticmethod
     def default_reserved():
         """Return the list of registers that should be reserved by default"""
-        return set(["flags", "sp",
-            "STACK_MASK1",
-            "STACK_MASK2",
-            "STACK_A_0",
-            "STACK_A_8",
-            "STACK_A_16",
-            "STACK_A_24",
-            "STACK_A_32",
-            "STACK_B_0",
-            "STACK_B_8",
-            "STACK_B_16",
-            "STACK_B_24",
-            "STACK_B_32",
-            "STACK_CTR",
-            "STACK_LASTBIT",
-            "STACK_SCALAR",
-            "STACK_X_0",
-            "STACK_X_8",
-            "STACK_X_16",
-            "STACK_X_24",
-            "STACK_X_32"
-                    ] + RegisterType.list_registers(RegisterType.HINT))
+        return set(["flags", "sp"] + RegisterType.list_registers(RegisterType.HINT))
 
     @staticmethod
     def default_aliases():

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -477,15 +477,6 @@ class Instruction:
             return False
         raise FatalParsingException(f"unknown datatype '{dt}' in {self}")
 
-    def is_vector_mul(self):
-        """Indicates if an instruction is a Neon vector multiplication"""
-        return self._is_instance_of([ vmul, vmul_lane,
-                                      vmla, vmls_lane, vmls,
-                                      vqrdmulh, vqrdmulh_lane, vqdmulh_lane,
-                                      vmull, vmlal ])
-    def is_vector_add_sub(self):
-        """Indicates if an instruction is a Neon add/sub operation"""
-        return self._is_instance_of([ vadd, vsub ])
     def is_vector_load(self):
         """Indicates if an instruction is a Neon load instruction"""
         return self._is_instance_of([ Ldr_Q, Ldp_Q ]) # TODO: Ld4 missing?

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -982,15 +982,10 @@ class Q_Ld2_Lane_Post_Inc(AArch64Instruction):
 
 class q_ld2_lane_post_inc(Q_Ld2_Lane_Post_Inc): # pylint: disable=missing-docstring,invalid-name
     pattern = "ld2 { <Va>.<dt0>, <Vb>.<dt1> }[<index>], [<Xa>], <imm>"
-    # TODO: Model sp dependency
-    inputs = ["Xa"]
-    in_outs = ["Va", "Vb"]
+    in_outs = ["Va", "Vb", "Xa"]
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        obj.increment = obj.immediate
-        obj.pre_index = None
-        obj.addr = obj.args_in[0]
         obj.detected_q_ld2_lane_post_inc_pair = False
         obj.args_in_out_combinations = [
                 ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
@@ -1003,7 +998,7 @@ class q_ld2_lane_post_inc(Q_Ld2_Lane_Post_Inc): # pylint: disable=missing-docstr
 class q_ld2_lane_post_inc_force_output(Q_Ld2_Lane_Post_Inc): # pylint: disable=missing-docstring,invalid-name
     pattern = "ld2 { <Va>.<dt0>, <Vb>.<dt1> }[<index>], [<Xa>], <imm>"
     # TODO: Model sp dependency
-    inputs = ["Xa"]
+    in_outs = ["Xa"]
     outputs = ["Va", "Vb"]
     @classmethod
     def make(cls, src, force=False):
@@ -1011,9 +1006,6 @@ class q_ld2_lane_post_inc_force_output(Q_Ld2_Lane_Post_Inc): # pylint: disable=m
             raise Instruction.ParsingException("Instruction ignored")
 
         obj = AArch64Instruction.build(cls, src)
-        obj.increment = obj.immediate
-        obj.pre_index = None
-        obj.addr = obj.args_in[0]
         obj.args_out_combinations = [
                 ( [0,1], [ [ f"v{i}", f"v{i+1}" ] for i in range(0,30) ] )
             ]

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -1092,7 +1092,7 @@ class q_ldr1_stack(AArch64Instruction): # pylint: disable=missing-docstring,inva
     def write(self):
         return super().write()
 
-class q_ldr_stack_with_inc(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
+class q_ldr_stack_with_inc(Ldr_Q): # pylint: disable=missing-docstring,invalid-name
     pattern = "ldr <Qa>, [sp, <imm>]"
     # TODO: Model sp dependency
     outputs = ["Qa"]
@@ -1239,7 +1239,7 @@ class d_str_stack_with_inc(AArch64Instruction): # pylint: disable=missing-docstr
         self.immediate = simplify(self.pre_index)
         return super().write()
 
-class q_str_stack_with_inc(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
+class q_str_stack_with_inc(Str_Q): # pylint: disable=missing-docstring,invalid-name
     pattern = "str <Qa>, [sp, <imm>]"
     inputs = ["Qa"] # TODO: Model sp dependency
     @classmethod

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -219,6 +219,8 @@ class Instruction:
         self.args_in_out_combinations = None
         self.args_in_combinations = None
 
+        self.offset_adjustable = True
+
     def global_parsing_cb(self,a, log=None):
         return False
 


### PR DESCRIPTION
* Reduce number of steps in X25519 optimization script
* Circumvent issue in address offset fixup by marking address-register of `ld2` as input-output and thereby bypassing fixup mechanism