### PR TITLE
Add CI for examples

### DIFF
--- a/.github/workflows/test_basic.yaml
+++ b/.github/workflows/test_basic.yaml
@@ -1,0 +1,96 @@
+name: Regression tests
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [ opened, synchronize, labeled ]
+jobs:
+  examples_dry_run:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        python3 example.py --dry-run
+  examples_basic:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        python3 example.py --examples simple0,simple1,simple0_loop,simple1_loop
+  examples_ntt_kyber_dilithium_helium_core:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        python3 example.py --examples ntt_kyber_1_23_45_67_m55,ntt_dilithium_12_34_56_78_m55 --timeout=300
+  examples_ntt_kyber_dilithium_neon_core:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        python3 example.py --examples ntt_kyber_123_4567_a55,ntt_dilithium_123_45678_a55 --timeout=300
+  sqmag:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        (cd paper/scripts && NO_LOG=Y ./slothy_sqmag.sh)
+  fft:
+    if: ${{ github.event.label.name == 'needs-ci' ||
+            github.event.pull_request.user.login == 'hanno-becker' ||
+            github.event.pull_request.user.login == 'dop-amin' ||
+            github.event.pull_request.user.login == 'mkannwischer'
+            }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install python dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Run examples
+      run: |
+        (cd paper/scripts && NO_LOG=Y ./slothy_fft.sh)

--- a/example.py
+++ b/example.py
@@ -88,7 +88,7 @@ class Example():
     def core(self, slothy):
         slothy.optimize()
 
-    def run(self, debug=False, dry_run=False, silent=False):
+    def run(self, debug=False, dry_run=False, silent=False, timeout=0):
 
         if dry_run is True:
             annotation = " (dry run only)"
@@ -129,7 +129,9 @@ class Example():
         slothy = Slothy(self.arch, self.target, logger=logger)
         slothy.load_source_from_file(self.infile_full)
 
-        if self.timeout is not None:
+        if timeout != 0:
+            slothy.config.timeout = timeout
+        elif self.timeout is not None:
             slothy.config.timeout = self.timeout
 
         if dry_run is True:
@@ -1311,6 +1313,7 @@ def main():
     parser.add_argument("--debug", default=False, action="store_true")
     parser.add_argument("--silent", default=False, action="store_true")
     parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=0)
 
     args = parser.parse_args()
     if args.examples != "all":
@@ -1332,7 +1335,7 @@ def main():
     for e in todo:
         for _ in range(iterations):
             run_example(e, debug=args.debug, dry_run=args.dry_run,
-                        silent=args.silent)
+                        silent=args.silent, timeout=args.timeout)
 
 if __name__ == "__main__":
     main()

--- a/example.py
+++ b/example.py
@@ -159,6 +159,7 @@ class Example2(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints["const"] = Arch_Armv81M.RegisterType.GPR
         slothy.optimize_loop("start")
 
@@ -169,6 +170,7 @@ class Example3(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.optimize_loop("start")
 
 
@@ -178,6 +180,7 @@ class CRT(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.selfcheck = True
         # Double the loop body to create more interleaving opportunities
         # Basically a tradeoff of code-size vs performance
@@ -199,6 +202,7 @@ class ntt_n256_l6_s32(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {r: Arch_Armv81M.RegisterType.GPR for r in
                                       ["root0",         "root1",         "root2",
                                        "root0_twisted", "root1_twisted", "root2_twisted"]}
@@ -213,6 +217,7 @@ class ntt_n256_l8_s32(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {
             "root0": Arch_Armv81M.RegisterType.GPR,
             "root1": Arch_Armv81M.RegisterType.GPR,
@@ -234,6 +239,7 @@ class intt_n256_l6_s32(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {
             "root0": Arch_Armv81M.RegisterType.GPR,
             "root1": Arch_Armv81M.RegisterType.GPR,
@@ -253,6 +259,7 @@ class intt_n256_l8_s32(Example):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {
             "root0": Arch_Armv81M.RegisterType.GPR,
             "root1": Arch_Armv81M.RegisterType.GPR,
@@ -281,6 +288,7 @@ class ntt_kyber_1_23_45_67(Example):
         self.timeout = timeout
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {
             "root0": Arch_Armv81M.RegisterType.GPR,
             "root1": Arch_Armv81M.RegisterType.GPR,

--- a/example.py
+++ b/example.py
@@ -1028,37 +1028,37 @@ class ntt_dilithium_1234_5678(Example):
 
         super().__init__(infile, name, rename=True, arch=arch, target=target, timeout=timeout)
 
-        def core(self, slothy):
-            conf = slothy.config.copy()
+    def core(self, slothy):
+        conf = slothy.config.copy()
 
-            slothy.config.sw_pipelining.enabled = True
-            slothy.config.sw_pipelining.minimize_overlapping = False
-            slothy.config.reserved_regs = [
-                f"x{i}" for i in range(0, 6)] + ["x30", "sp"]
-            slothy.config.reserved_regs += self.target_reserved
-            slothy.config.inputs_are_outputs = True
-            slothy.config.sw_pipelining.halving_heuristic = True
-            slothy.config.split_heuristic = True
-            slothy.config.split_heuristic_factor = 2
-            slothy.config.split_heuristic_repeat = 4
-            slothy.config.split_heuristic_stepsize = 0.1
-            slothy.config.constraints.stalls_first_attempt = 14
-            slothy.optimize_loop("layer1234_start")
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.minimize_overlapping = False
+        slothy.config.reserved_regs = [
+            f"x{i}" for i in range(0, 6)] + ["x30", "sp"]
+        slothy.config.reserved_regs += self.target_reserved
+        slothy.config.inputs_are_outputs = True
+        slothy.config.sw_pipelining.halving_heuristic = True
+        slothy.config.split_heuristic = True
+        slothy.config.split_heuristic_factor = 2
+        slothy.config.split_heuristic_repeat = 4
+        slothy.config.split_heuristic_stepsize = 0.1
+        slothy.config.constraints.stalls_first_attempt = 14
+        slothy.optimize_loop("layer1234_start")
 
-            slothy.config = conf.copy()
+        slothy.config = conf.copy()
 
-            if self.timeout is not None:
-                slothy.config.timeout = self.timeout * 12
+        if self.timeout is not None:
+            slothy.config.timeout = self.timeout * 12
 
-            slothy.config.reserved_regs = [
-                f"x{i}" for i in range(0, 6)] + ["x30", "sp"]
-            slothy.config.inputs_are_outputs = True
-            slothy.config.reserved_regs += self.target_reserved
-            slothy.config.sw_pipelining.enabled = True
-            slothy.config.sw_pipelining.minimize_overlapping = False
-            slothy.config.sw_pipelining.halving_heuristic = False
-            slothy.config.split_heuristic = False
-            slothy.optimize_loop("layer5678_start")
+        slothy.config.reserved_regs = [
+            f"x{i}" for i in range(0, 6)] + ["x30", "sp"]
+        slothy.config.inputs_are_outputs = True
+        slothy.config.reserved_regs += self.target_reserved
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.minimize_overlapping = False
+        slothy.config.sw_pipelining.halving_heuristic = False
+        slothy.config.split_heuristic = False
+        slothy.optimize_loop("layer5678_start")
 
 
 class ntt_dilithium_1234(Example):

--- a/example.py
+++ b/example.py
@@ -253,7 +253,7 @@ class intt_n256_l8_s32(Example):
 
 
 class ntt_kyber_1_23_45_67(Example):
-    def __init__(self, var="", arch=Arch_Armv81M, target=Target_CortexM55r1):
+    def __init__(self, var="", arch=Arch_Armv81M, target=Target_CortexM55r1, timeout=None):
         name = "ntt_kyber_1_23_45_67"
         infile = name
         if var != "":
@@ -262,7 +262,7 @@ class ntt_kyber_1_23_45_67(Example):
         name += f"_{target_label_dict[target]}"
         super().__init__(infile, name=name, arch=arch, target=target, rename=True)
         self.var = var
-
+        self.timeout = timeout
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.typing_hints = {
@@ -278,6 +278,8 @@ class ntt_kyber_1_23_45_67(Example):
         slothy.optimize_loop("layer23_loop")
         slothy.optimize_loop("layer45_loop")
         slothy.config.constraints.st_ld_hazard = False
+        if self.timeout is not None:
+            slothy.config.timeout = self.timeout
         if "no_trans" in self.var:
             slothy.config.constraints.st_ld_hazard = True
         slothy.config.typing_hints = {}
@@ -835,6 +837,8 @@ class ntt_dilithium_123_456_78(Example):
         self.var = var
 
     def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 16
         slothy.config.inputs_are_outputs = True
         slothy.config.typing_hints = {
             "root2": Arch_Armv81M.RegisterType.GPR,
@@ -848,8 +852,6 @@ class ntt_dilithium_123_456_78(Example):
             "root5_tw": Arch_Armv81M.RegisterType.GPR,
             "root6_tw": Arch_Armv81M.RegisterType.GPR,
         }
-        slothy.config.constraints.stalls_minimum_attempt = 0
-        slothy.config.constraints.stalls_first_attempt = 0
         slothy.config.locked_registers = set([f"QSTACK{i}" for i in [4, 5, 6]] +
                                              [f"ROOT{i}_STACK" for i in [0, 1, 4]] + ["RPTR_STACK"])
         if self.var != "" or ("speed" in self.name and self.target == Target_CortexM85r1):
@@ -1163,16 +1165,15 @@ def main():
                  # Cortex-M55
                  ntt_kyber_1_23_45_67(),
                  ntt_kyber_1_23_45_67(var="no_trans"),
-                 ntt_kyber_1_23_45_67(var="no_trans_vld4"),
+                 ntt_kyber_1_23_45_67(var="no_trans_vld4", timeout=600),
                  ntt_kyber_12_345_67(False),
                  ntt_kyber_12_345_67(True),
                  # Cortex-M85
                  ntt_kyber_1_23_45_67(target=Target_CortexM85r1),
                  ntt_kyber_1_23_45_67(var="no_trans", target=Target_CortexM85r1),
-                 ntt_kyber_1_23_45_67(var="no_trans_vld4", target=Target_CortexM85r1),
+                 ntt_kyber_1_23_45_67(var="no_trans_vld4", target=Target_CortexM85r1, timeout=600),
                  ntt_kyber_12_345_67(False, target=Target_CortexM85r1),
                  ntt_kyber_12_345_67(True, target=Target_CortexM85r1),
-                 ntt_kyber_l345_symbolic(),
                  # Cortex-A55
                  ntt_kyber_123_4567(),
                  ntt_kyber_123_4567(var="scalar_load"),
@@ -1217,7 +1218,6 @@ def main():
                  ntt_dilithium_12_34_56_78(var="no_trans_vld4", target=Target_CortexM85r1),
                  ntt_dilithium_123_456_78(False, target=Target_CortexM85r1),
                  ntt_dilithium_123_456_78(True, target=Target_CortexM85r1),
-                 ntt_dilithium_123_456_78_symbolic(),
                  # Cortex-A55
                  ntt_dilithium_123_45678(),
                  ntt_dilithium_123_45678(var="w_scalar"),
@@ -1251,7 +1251,7 @@ def main():
                  fft_floatingpoint_radix4(),
                  # Fixed point
                  fft_fixedpoint_radix4(),
-                ]
+                 ]
 
     all_example_names = [e.name for e in examples]
 

--- a/example.py
+++ b/example.py
@@ -1145,6 +1145,11 @@ class fft_fixedpoint_radix4(Example):
                          rename=True, arch=arch, target=target)
 
     def core(self, slothy):
+        # This is default value, but it's overwritten in case of a dry-run.
+        # However, the symbolic registers in the FLT FFT cannot be resolved
+        # without reordering, so let's ignore the dry-run parameter here.
+        slothy.config.constraints.allow_reordering = True
+
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
         slothy.config.sw_pipelining.minimize_overlapping = False
@@ -1169,8 +1174,13 @@ class fft_floatingpoint_radix4(Example):
                          rename=True, arch=arch, target=target)
 
     def core(self, slothy):
+        # This is default value, but it's overwritten in case of a dry-run.
+        # However, the symbolic registers in the FLT FFT cannot be resolved
+        # without reordering, so let's ignore the dry-run parameter here.
+        slothy.config.constraints.allow_reordering = True
+
         slothy.config.sw_pipelining.enabled = True
-        # slothy.config.inputs_are_outputs = True
+        slothy.config.inputs_are_outputs = True
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False

--- a/examples/naive/aarch64/X25519-AArch64-simple.s
+++ b/examples/naive/aarch64/X25519-AArch64-simple.s
@@ -27,6 +27,11 @@
  */
 
 #include <hal_env.h>
+#include "instruction_wrappers.i"
+
+.macro fcsel_dform out, in0, in1, cond // @slothy:no-unfold
+  fcsel dform_\out, dform_\in0, dform_\in1, \cond
+.endm
 
 #define STACK_MASK1     0
 #define STACK_MASK2     8

--- a/examples/naive/aarch64/intt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/intt_dilithium_1234_5678.s
@@ -177,7 +177,7 @@
         trn1_d \data\()1, t1, t3
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -188,7 +188,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -198,7 +198,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -206,7 +206,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -217,19 +217,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/ntt_dilithium_1234_5678.s
@@ -137,7 +137,7 @@
         trn1 \data\()1.2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -148,7 +148,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -158,7 +158,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -166,7 +166,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -177,19 +177,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_1234_5678_manual_st4.s
+++ b/examples/naive/aarch64/ntt_dilithium_1234_5678_manual_st4.s
@@ -143,7 +143,7 @@
         trn1 \data1\().2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -154,7 +154,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -164,7 +164,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -172,7 +172,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -183,19 +183,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678.s
@@ -186,7 +186,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -197,7 +197,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -215,7 +215,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -226,19 +226,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_manual_st4.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_manual_st4.s
@@ -186,7 +186,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -197,7 +197,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -215,7 +215,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -226,19 +226,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_red.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_red.s
@@ -154,7 +154,7 @@
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -165,7 +165,7 @@
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -175,7 +175,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -183,7 +183,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -194,19 +194,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar.s
@@ -196,7 +196,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -217,7 +217,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -225,7 +225,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -236,19 +236,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar_red.s
+++ b/examples/naive/aarch64/ntt_dilithium_123_45678_w_scalar_red.s
@@ -185,7 +185,7 @@ xtmp1 .req x11
         trn2 \data_out3\().4s, \data_in2\().4s, \data_in3\().4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -196,7 +196,7 @@ xtmp1 .req x11
         stp x29, x30, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -206,7 +206,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -214,7 +214,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -225,19 +225,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_1234_567.s
+++ b/examples/naive/aarch64/ntt_kyber_1234_567.s
@@ -138,7 +138,7 @@
         trn1 \data\()1.2d, t1.2d, t3.2d
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -149,7 +149,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -159,7 +159,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -167,7 +167,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -178,19 +178,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_1234_567_manual_st4.s
+++ b/examples/naive/aarch64/ntt_kyber_1234_567_manual_st4.s
@@ -146,7 +146,7 @@
         str_vo \a3, \addr, (-(\inc) + 16*3)
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -157,7 +157,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -167,7 +167,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -175,7 +175,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -186,19 +186,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567.s
@@ -139,7 +139,7 @@
         trn2 \data_out\()3.4s, \data_in\()2.4s, \data_in\()3.4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -150,7 +150,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -160,7 +160,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -168,7 +168,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -179,19 +179,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_manual_st4.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_manual_st4.s
@@ -146,7 +146,7 @@
         trn2 \data_out\()3.4s, \data_in\()2.4s, \data_in\()3.4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -157,7 +157,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -167,7 +167,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -175,7 +175,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -186,19 +186,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load.s
@@ -151,7 +151,7 @@ xtmp1 .req x11
         trn2 \data_out\()3.4s, \data_in\()2.4s, \data_in\()3.4s
 .endm
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -162,7 +162,7 @@ xtmp1 .req x11
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -172,7 +172,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -180,7 +180,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -191,19 +191,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load_store.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_load_store.s
@@ -178,7 +178,7 @@ xtmp1 .req x11
 .endm
 
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -189,7 +189,7 @@ xtmp1 .req x11
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -199,7 +199,7 @@ xtmp1 .req x11
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -207,7 +207,7 @@ xtmp1 .req x11
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -218,19 +218,19 @@ xtmp1 .req x11
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/aarch64/ntt_kyber_123_4567_scalar_store.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567_scalar_store.s
@@ -165,7 +165,7 @@
 .endm
 
 
-.macro save_gprs // slothy:no-unfold
+.macro save_gprs // @slothy:no-unfold
         sub sp, sp, #(16*6)
         stp x19, x20, [sp, #16*0]
         stp x19, x20, [sp, #16*0]
@@ -176,7 +176,7 @@
         str x29, [sp, #16*5]
 .endm
 
-.macro restore_gprs // slothy:no-unfold
+.macro restore_gprs // @slothy:no-unfold
         ldp x19, x20, [sp, #16*0]
         ldp x21, x22, [sp, #16*1]
         ldp x23, x24, [sp, #16*2]
@@ -186,7 +186,7 @@
         add sp, sp, #(16*6)
 .endm
 
-.macro save_vregs // slothy:no-unfold
+.macro save_vregs // @slothy:no-unfold
         sub sp, sp, #(16*4)
         stp  d8,  d9, [sp, #16*0]
         stp d10, d11, [sp, #16*1]
@@ -194,7 +194,7 @@
         stp d14, d15, [sp, #16*3]
 .endm
 
-.macro restore_vregs // slothy:no-unfold
+.macro restore_vregs // @slothy:no-unfold
         ldp  d8,  d9, [sp, #16*0]
         ldp d10, d11, [sp, #16*1]
         ldp d12, d13, [sp, #16*2]
@@ -205,19 +205,19 @@
 #define STACK_SIZE 16
 #define STACK0 0
 
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
-.macro push_stack // slothy:no-unfold
+.macro push_stack // @slothy:no-unfold
         save_gprs
         save_vregs
         sub sp, sp, #STACK_SIZE
 .endm
 
-.macro pop_stack // slothy:no-unfold
+.macro pop_stack // @slothy:no-unfold
         add sp, sp, #STACK_SIZE
         restore_vregs
         restore_gprs

--- a/examples/naive/intt_dilithium_12_34_56_78.s
+++ b/examples/naive/intt_dilithium_12_34_56_78.s
@@ -77,7 +77,7 @@ intt_dilithium_12_34_56_78:
 
         tmp .req q4
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         mov lr, #16
 layer78_loop:
@@ -122,7 +122,7 @@ layer78_loop:
         root2         .req r6
         root2_twisted .req r7
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
 layer56_loop:
@@ -169,7 +169,7 @@ layer56_loop:
         sub in, in, #(4*256)
         .unreq barrett_const
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -231,7 +231,7 @@ layer34_loop:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/naive/intt_kyber_1_23_45_67.s
+++ b/examples/naive/intt_kyber_1_23_45_67.s
@@ -86,7 +86,7 @@ intt_kyber_1_23_45_67:
 
         tmp .req q4
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         mov lr, #8
 layer67_loop:
@@ -153,7 +153,7 @@ layer67_loop:
         sub in, in, #(4*128)
         .unreq barrett_const
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
 layer45_loop:
@@ -198,7 +198,7 @@ layer45_loop:
         sub in, in, #(4*128)
         .unreq barrett_const
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -252,7 +252,7 @@ layer23_loop:
         in_high      .req r1
         add in_high, in_low, #(4*64)
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 

--- a/examples/naive/intt_n256_l6_s32_bar.s
+++ b/examples/naive/intt_n256_l6_s32_bar.s
@@ -77,7 +77,7 @@ invntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
 layer56_loop:
@@ -120,7 +120,7 @@ layer56_loop:
         sub in, in, #(4*256)
         .unreq barrett_const
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -178,7 +178,7 @@ layer34_loop:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/naive/intt_n256_l6_s32_mont.s
+++ b/examples/naive/intt_n256_l6_s32_mont.s
@@ -202,7 +202,7 @@ invntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
 layer56_loop:
@@ -248,7 +248,7 @@ layer56_loop:
         .unreq barrett_const
         .unreq modulus_neg
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -309,7 +309,7 @@ layer34_loop:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/naive/intt_n256_l8_s32_bar.s
+++ b/examples/naive/intt_n256_l8_s32_bar.s
@@ -81,7 +81,7 @@ invntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         mov lr, #16
 layer78_loop:
@@ -126,7 +126,7 @@ layer78_loop:
         root2         .req r6
         root2_twisted .req r7
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
 layer56_loop:
@@ -169,7 +169,7 @@ layer56_loop:
         sub in, in, #(4*256)
         .unreq barrett_const
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -227,7 +227,7 @@ layer34_loop:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/naive/intt_n256_l8_s32_mont.s
+++ b/examples/naive/intt_n256_l8_s32_mont.s
@@ -686,7 +686,7 @@ invntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         mov lr, #16
 layer78_loop:
@@ -731,7 +731,7 @@ layer78_loop:
         root2         .req r6
         root2_twisted .req r7
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
 layer56_loop:
@@ -777,7 +777,7 @@ layer56_loop:
         .unreq barrett_const
         .unreq modulus_neg
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -838,7 +838,7 @@ layer34_loop:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/naive/ntt_dilithium_123_456_78.s
+++ b/examples/naive/ntt_dilithium_123_456_78.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -209,7 +209,7 @@ layer123_loop:
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw
@@ -276,7 +276,7 @@ layer456_loop:
         .unreq root2
         .unreq root2_tw
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         root0         .req q5
         root0_tw .req q6

--- a/examples/naive/ntt_dilithium_123_456_78.s
+++ b/examples/naive/ntt_dilithium_123_456_78.s
@@ -42,27 +42,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -71,7 +71,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_dilithium_123_456_78_symbolic.s
+++ b/examples/naive/ntt_dilithium_123_456_78_symbolic.s
@@ -44,27 +44,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -73,7 +73,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_dilithium_123_456_78_symbolic.s
+++ b/examples/naive/ntt_dilithium_123_456_78_symbolic.s
@@ -137,7 +137,7 @@ ntt_dilithium_123_456_78:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -211,7 +211,7 @@ layer123_loop:
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw
@@ -271,7 +271,7 @@ layer456_loop:
         .unreq root2
         .unreq root2_tw
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         root0         .req q5
         root0_tw .req q6

--- a/examples/naive/ntt_dilithium_123_456_78_trans.s
+++ b/examples/naive/ntt_dilithium_123_456_78_trans.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_trans:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -209,7 +209,7 @@ layer123_loop:
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw
@@ -276,7 +276,7 @@ layer456_loop:
         .unreq root2
         .unreq root2_tw
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         root0         .req q5
         root0_tw .req q6

--- a/examples/naive/ntt_dilithium_123_456_78_trans.s
+++ b/examples/naive/ntt_dilithium_123_456_78_trans.s
@@ -42,27 +42,27 @@ roots:
         vadd.u32       \a,    \a, tmp
 .endm
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC   // 8 of ==8 mod 16, 0 otherwise
         sub sp, sp, r12      // Align stack to 16 byte
@@ -71,7 +71,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_dilithium_12_34_56_78.s
+++ b/examples/naive/ntt_dilithium_12_34_56_78.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -104,7 +104,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -138,7 +138,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16
@@ -160,7 +160,7 @@ layer56_loop:
         vst43.u32 {data0, data1, data2, data3}, [in]!
         le lr, layer56_loop
 
-        /* Layers 7,8 */
+        // Layers 7,8
         sub in, in, #(4*256)
 
         .unreq root0

--- a/examples/naive/ntt_dilithium_12_34_56_78_no_trans_vld4.s
+++ b/examples/naive/ntt_dilithium_12_34_56_78_no_trans_vld4.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -104,7 +104,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -138,7 +138,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16
@@ -160,7 +160,7 @@ layer56_loop:
         vstrw.u32 data3, [in, #(-64+48)]
         le lr, layer56_loop
 
-        /* Layers 7,8 */
+        // Layers 7,8
         sub in, in, #(4*256)
 
         .unreq root0

--- a/examples/naive/ntt_kyber_12_345_67.s
+++ b/examples/naive/ntt_kyber_12_345_67.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)
@@ -167,7 +167,7 @@ layer12_loop:
         vstrw.u32 data3, [in_high, #(2*64 - 16)]
         le lr, layer12_loop
 
-        /* Layers 3,4,5 */
+        // Layers 3,4,5
 
         restore in, STACK0
         mov lr, #4

--- a/examples/naive/ntt_kyber_12_345_67.s
+++ b/examples/naive/ntt_kyber_12_345_67.s
@@ -44,22 +44,22 @@ roots:
 
 #define STACK_SIZE (3*16 + 8)
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
@@ -77,7 +77,7 @@ roots:
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC
         sub sp, sp, r12      // Align stack to 16 byte
@@ -86,7 +86,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_kyber_12_345_67_trans.s
+++ b/examples/naive/ntt_kyber_12_345_67_trans.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_trans:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)
@@ -167,7 +167,7 @@ layer12_loop:
         vstrw.u32 data3, [in_high, #(2*64 - 16)]
         le lr, layer12_loop
 
-        /* Layers 3,4,5 */
+        // Layers 3,4,5
 
         restore in, STACK0
         mov lr, #4

--- a/examples/naive/ntt_kyber_12_345_67_trans.s
+++ b/examples/naive/ntt_kyber_12_345_67_trans.s
@@ -44,22 +44,22 @@ roots:
 
 #define STACK_SIZE (3*16 + 8)
 
-.macro qsave loc, a       // slothy:no-unfold
+.macro qsave loc, a       // @slothy:no-unfold
         vstrw.32 \a, [sp, #\loc\()]
 .endm
-.macro qrestore a, loc    // slothy:no-unfold
+.macro qrestore a, loc    // @slothy:no-unfold
         vldrw.32 \a, [sp, #\loc\()]
 .endm
-.macro restored a, b, loc // slothy:no-unfold
+.macro restored a, b, loc // @slothy:no-unfold
         ldrd \a, \b, [sp, #\loc\()]
 .endm
-.macro saved loc, a, b    // slothy:no-unfold
+.macro saved loc, a, b    // @slothy:no-unfold
         strd \a, \b, [sp, #\loc\()]
 .endm
-.macro restore a, loc     // slothy:no-unfold
+.macro restore a, loc     // @slothy:no-unfold
         ldr \a, [sp, #\loc\()]
 .endm
-.macro save loc, a        // slothy:no-unfold
+.macro save loc, a        // @slothy:no-unfold
         str \a, [sp, #\loc\()]
 .endm
 
@@ -77,7 +77,7 @@ roots:
 .endm
 
 // Aligns stack =0 mod 16
-.macro align_stack_do // slothy:no-unfold
+.macro align_stack_do // @slothy:no-unfold
         mov r11, sp
         and r12, r11, #0xC
         sub sp, sp, r12      // Align stack to 16 byte
@@ -86,7 +86,7 @@ roots:
 .endm
 
 // Reverts initial stack correction
-.macro align_stack_undo // slothy:no-unfold
+.macro align_stack_undo // @slothy:no-unfold
         ldr r12, [sp]
         add sp, sp, #16
         add sp, sp, r12

--- a/examples/naive/ntt_kyber_1_23_45_67.s
+++ b/examples/naive/ntt_kyber_1_23_45_67.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -110,7 +110,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -143,7 +143,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
 layer45_loop:
@@ -168,7 +168,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/naive/ntt_kyber_1_23_45_67_no_trans.s
+++ b/examples/naive/ntt_kyber_1_23_45_67_no_trans.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -110,7 +110,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -143,7 +143,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
 layer45_loop:
@@ -168,7 +168,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/naive/ntt_kyber_1_23_45_67_no_trans_vld4.s
+++ b/examples/naive/ntt_kyber_1_23_45_67_no_trans_vld4.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans_vld4:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -110,7 +110,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -143,7 +143,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
 layer45_loop:
@@ -168,7 +168,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/naive/ntt_n256_l6_s32_bar.s
+++ b/examples/naive/ntt_n256_l6_s32_bar.s
@@ -87,7 +87,7 @@ ntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -117,7 +117,7 @@ layer12_loop:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -155,7 +155,7 @@ layer34_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs

--- a/examples/naive/ntt_n256_l6_s32_mont.s
+++ b/examples/naive/ntt_n256_l6_s32_mont.s
@@ -212,7 +212,7 @@ ntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -242,7 +242,7 @@ layer12_loop:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -280,7 +280,7 @@ layer34_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs

--- a/examples/naive/ntt_n256_l8_s32_bar.s
+++ b/examples/naive/ntt_n256_l8_s32_bar.s
@@ -80,7 +80,7 @@ ntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -110,7 +110,7 @@ layer12_loop:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -148,7 +148,7 @@ layer34_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs
@@ -178,7 +178,7 @@ layer56_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/naive/ntt_n256_l8_s32_mont.s
+++ b/examples/naive/ntt_n256_l8_s32_mont.s
@@ -596,7 +596,7 @@ ntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -626,7 +626,7 @@ layer12_loop:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -664,7 +664,7 @@ layer34_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs
@@ -694,7 +694,7 @@ layer56_loop:
 
         sub in, in, #(4*256)
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/intt_n256_l6_s32_bar.s
+++ b/examples/opt/intt_n256_l6_s32_bar.s
@@ -77,7 +77,7 @@ invntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
         ldrd r1, r10, [root_ptr, #16]          // *...
@@ -238,7 +238,7 @@ layer56_loop_end:
         sub in, in, #(4*256)
         .unreq barrett_const
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -406,7 +406,7 @@ layer34_loop_end:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/opt/intt_n256_l6_s32_mont.s
+++ b/examples/opt/intt_n256_l6_s32_mont.s
@@ -202,7 +202,7 @@ invntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
         ldrd r1, r10, [root_ptr, #16]          // *...
@@ -366,7 +366,7 @@ layer56_loop_end:
         .unreq barrett_const
         .unreq modulus_neg
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -537,7 +537,7 @@ layer34_loop_end:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/opt/intt_n256_l8_s32_bar.s
+++ b/examples/opt/intt_n256_l8_s32_bar.s
@@ -81,7 +81,7 @@ invntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         mov lr, #16
         vldrw.u32 q1, [in, #16]                // *....
@@ -254,7 +254,7 @@ layer78_loop_end:
         root2         .req r6
         root2_twisted .req r7
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
         ldrd r1, r2, [root_ptr, #16]          // *.......
@@ -423,7 +423,7 @@ layer56_loop_end:
         sub in, in, #(4*256)
         .unreq barrett_const
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -591,7 +591,7 @@ layer34_loop_end:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/opt/intt_n256_l8_s32_mont.s
+++ b/examples/opt/intt_n256_l8_s32_mont.s
@@ -686,7 +686,7 @@ invntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         mov lr, #16
         vldrw.u32 q4, [root_ptr, #80]          // *....
@@ -861,7 +861,7 @@ layer78_loop_end:
         root2         .req r6
         root2_twisted .req r7
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         mov lr, #16
         vld40.u32 {q4,q5,q6,q7}, [in]         // *.......
@@ -1036,7 +1036,7 @@ layer56_loop_end:
         .unreq barrett_const
         .unreq modulus_neg
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -1210,7 +1210,7 @@ layer34_loop_end:
         in_high      .req r1
         add in_high, in_low, #(4*128)
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8

--- a/examples/opt/ntt_dilithium_123_456_78_opt_size_m55.s
+++ b/examples/opt/ntt_dilithium_123_456_78_opt_size_m55.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_opt_size_m55:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -341,7 +341,7 @@ layer123_loop:
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw
@@ -542,7 +542,7 @@ layer456_loop:
         .unreq root2
         .unreq root2_tw
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         root0         .req q5
         root0_tw .req q6

--- a/examples/opt/ntt_dilithium_123_456_78_opt_size_m85.s
+++ b/examples/opt/ntt_dilithium_123_456_78_opt_size_m85.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_opt_size_m85:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -341,7 +341,7 @@ layer123_loop:
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw
@@ -542,7 +542,7 @@ layer456_loop:
         .unreq root2
         .unreq root2_tw
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         root0         .req q5
         root0_tw .req q6

--- a/examples/opt/ntt_dilithium_123_456_78_opt_speed.s
+++ b/examples/opt/ntt_dilithium_123_456_78_opt_speed.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_opt_speed:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -429,7 +429,7 @@ layer123_loop_end: // end of loop kernel
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw

--- a/examples/opt/ntt_dilithium_123_456_78_opt_speed_m55.s
+++ b/examples/opt/ntt_dilithium_123_456_78_opt_speed_m55.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_opt_speed_m55:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -428,7 +428,7 @@ layer123_loop_end: // end of loop kernel
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw

--- a/examples/opt/ntt_dilithium_123_456_78_opt_speed_m85.s
+++ b/examples/opt/ntt_dilithium_123_456_78_opt_speed_m85.s
@@ -135,7 +135,7 @@ ntt_dilithium_123_456_78_opt_speed_m85:
 
         tmp .req q7
 
-        /* Layers 1-3 */
+        // Layers 1-3
 
         rtmp    .req root6
         rtmp_tw .req root6_tw
@@ -428,7 +428,7 @@ layer123_loop_end: // end of loop kernel
         sub in, in, #(128)
         restore r_ptr, RPTR_STACK
 
-        /* Layers 4,5,6 */
+        // Layers 4,5,6
 
         .unreq rtmp
         .unreq rtmp_tw

--- a/examples/opt/ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m55.s
+++ b/examples/opt/ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m55.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m55:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -217,7 +217,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -364,7 +364,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16

--- a/examples/opt/ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m85.s
+++ b/examples/opt/ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m85.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78_no_trans_vld4_opt_m85:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -216,7 +216,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -362,7 +362,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16

--- a/examples/opt/ntt_dilithium_12_34_56_78_opt.s
+++ b/examples/opt/ntt_dilithium_12_34_56_78_opt.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78_opt:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -218,7 +218,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -366,7 +366,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16

--- a/examples/opt/ntt_dilithium_12_34_56_78_opt_m55.s
+++ b/examples/opt/ntt_dilithium_12_34_56_78_opt_m55.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78_opt_m55:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -217,7 +217,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -364,7 +364,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16

--- a/examples/opt/ntt_dilithium_12_34_56_78_opt_m85.s
+++ b/examples/opt/ntt_dilithium_12_34_56_78_opt_m85.s
@@ -79,7 +79,7 @@ ntt_dilithium_12_34_56_78_opt_m85:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
         ldrd root2, root2_twisted, [root_ptr], #+8
@@ -216,7 +216,7 @@ layer12_loop:
         .unreq in_low
         in .req r0
 
-        /* Layers 3,4 */
+        // Layers 3,4
         sub in, in, #(64*4)
 
         // 4 butterfly blocks per root config, 4 root configs
@@ -362,7 +362,7 @@ layer34_loop:
         subs count, count, #1
         bne out_start
 
-        /* Layers 5,6 */
+        // Layers 5,6
         sub in, in, #(4*256)
 
         mov lr, #16

--- a/examples/opt/ntt_dilithium_paper.s
+++ b/examples/opt/ntt_dilithium_paper.s
@@ -79,7 +79,7 @@ ntt_dilithium:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -223,7 +223,7 @@ layer12_loop_end:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -375,7 +375,7 @@ layer34_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs
@@ -537,7 +537,7 @@ layer56_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_12_345_67_opt_size.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_size.s
@@ -141,7 +141,7 @@ ntt_kyber_12_345_67_opt_size:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)
@@ -282,7 +282,7 @@ layer12_loop_end: // end of loop kernel
         // nop                            // ............*...........
         
 
-        /* Layers 3,4,5 */
+        // Layers 3,4,5
 
         restore in, STACK0
         mov lr, #4
@@ -472,7 +472,7 @@ layer345_loop:
         
         le lr, layer345_loop
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         restore in, STACK0
         mov lr, #8

--- a/examples/opt/ntt_kyber_12_345_67_opt_size_m55.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_size_m55.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_opt_size_m55:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)
@@ -281,7 +281,7 @@ layer12_loop_end: // end of loop kernel
         // vstrw.u32 q0, [r0] , #16       // ..................*.... 
         
 
-        /* Layers 3,4,5 */
+        // Layers 3,4,5
 
         restore in, STACK0
         mov lr, #4

--- a/examples/opt/ntt_kyber_12_345_67_opt_size_m85.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_size_m85.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_opt_size_m85:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)
@@ -280,7 +280,7 @@ layer12_loop_end: // end of loop kernel
         // vstrw.u32 q0, [r0, #112]       // .....................*.... 
         
 
-        /* Layers 3,4,5 */
+        // Layers 3,4,5
 
         restore in, STACK0
         mov lr, #4

--- a/examples/opt/ntt_kyber_12_345_67_opt_speed.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_speed.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_opt_speed:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)

--- a/examples/opt/ntt_kyber_12_345_67_opt_speed_m55.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_speed_m55.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_opt_speed_m55:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)

--- a/examples/opt/ntt_kyber_12_345_67_opt_speed_m85.s
+++ b/examples/opt/ntt_kyber_12_345_67_opt_speed_m85.s
@@ -142,7 +142,7 @@ ntt_kyber_12_345_67_opt_speed_m85:
         movw modulus, #:lower16:modulus_const
         ldr  r_ptr, roots_addr
 
-        /* Layers 1,2 */
+        // Layers 1,2
 
         save STACK0, in
         add in_high, in_low, #(2*128)

--- a/examples/opt/ntt_kyber_1_23_45_67_no_trans_opt_m55.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_no_trans_opt_m55.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans_opt_m55:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -152,7 +152,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -295,7 +295,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r3, r7, [r11] , #24         // ..*....
@@ -445,7 +445,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_no_trans_opt_m85.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_no_trans_opt_m85.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans_opt_m85:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -150,7 +150,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -292,7 +292,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r3, r8, [r11] , #24         // *......
@@ -442,7 +442,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_no_trans_vld4_opt_m55.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_no_trans_vld4_opt_m55.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans_vld4_opt_m55:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -152,7 +152,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -295,7 +295,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r9, r4, [r11] , #24         // *......
@@ -438,7 +438,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_no_trans_vld4_opt_m85.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_no_trans_vld4_opt_m85.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_no_trans_vld4_opt_m85:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -150,7 +150,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -292,7 +292,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
 .p2align 2
@@ -366,7 +366,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_opt.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_opt.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_opt:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -122,7 +122,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -198,7 +198,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r8, r6, [r11] , #24
@@ -270,7 +270,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_opt_m55.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_opt_m55.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_opt_m55:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -152,7 +152,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -295,7 +295,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r1, r9, [r11] , #24           // ..*....
@@ -445,7 +445,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_1_23_45_67_opt_m85.s
+++ b/examples/opt/ntt_kyber_1_23_45_67_opt_m85.s
@@ -89,7 +89,7 @@ ntt_kyber_1_23_45_67_opt_m85:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -150,7 +150,7 @@ layer1_loop:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -292,7 +292,7 @@ layer23_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r8, r10, [r11] , #24         // *......
@@ -442,7 +442,7 @@ layer45_loop:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_kyber_paper.s
+++ b/examples/opt/ntt_kyber_paper.s
@@ -89,7 +89,7 @@ ntt_kyber:
 
         tmp .req q4
 
-        /* Layers 1 */
+        // Layers 1
 
         load_first_root root0, root0_twisted
 
@@ -157,7 +157,7 @@ layer1_loop_end:
         in .req r0
         sub in, in, #(4*64)
 
-        /* Layers 2,3 */
+        // Layers 2,3
 
         count .req r1
         mov count, #2
@@ -304,7 +304,7 @@ layer23_loop_end:
 
         sub in, in, #(4*128)
 
-        /* Layers 4,5 */
+        // Layers 4,5
 
         mov lr, #8
         ldrd r4, r6, [root_ptr] , #24          // ..*....
@@ -463,7 +463,7 @@ layer45_loop_end:
 
         sub in, in, #(4*128)
 
-        /* Layers 6,7 */
+        // Layers 6,7
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_n256_l6_s32_bar.s
+++ b/examples/opt/ntt_n256_l6_s32_bar.s
@@ -87,7 +87,7 @@ ntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -229,7 +229,7 @@ layer12_loop_end:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -379,7 +379,7 @@ layer34_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs

--- a/examples/opt/ntt_n256_l6_s32_mont.s
+++ b/examples/opt/ntt_n256_l6_s32_mont.s
@@ -212,7 +212,7 @@ ntt_n256_u32_33556993_28678040_incomplete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -354,7 +354,7 @@ layer12_loop_end:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -504,7 +504,7 @@ layer34_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs

--- a/examples/opt/ntt_n256_l8_s32_bar.s
+++ b/examples/opt/ntt_n256_l8_s32_bar.s
@@ -80,7 +80,7 @@ ntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -222,7 +222,7 @@ layer12_loop_end:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -372,7 +372,7 @@ layer34_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs
@@ -532,7 +532,7 @@ layer56_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         .unreq root0
         .unreq root0_twisted

--- a/examples/opt/ntt_n256_l8_s32_mont.s
+++ b/examples/opt/ntt_n256_l8_s32_mont.s
@@ -596,7 +596,7 @@ ntt_n256_u32_33556993_28678040_complete_manual:
 
         tmp .req q4
 
-        /* Layers 1-2 */
+        // Layers 1-2
 
         ldrd root0, root0_twisted, [root_ptr], #+8
         ldrd root1, root1_twisted, [root_ptr], #+8
@@ -738,7 +738,7 @@ layer12_loop_end:
         in .req r0
         sub in, in, #(64*4)
 
-        /* Layers 3,4 */
+        // Layers 3,4
 
         // 4 butterfly blocks per root config, 4 root configs
         // loop over root configs
@@ -888,7 +888,7 @@ layer34_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 5,6 */
+        // Layers 5,6
 
         // 1 butterfly blocks per root config, 16 root configs
         // loop over root configs
@@ -1048,7 +1048,7 @@ layer56_loop_end:
 
         sub in, in, #(4*256)
 
-        /* Layers 7,8 */
+        // Layers 7,8
 
         .unreq root0
         .unreq root0_twisted

--- a/paper/scripts/slothy_dilithium_ntt_a55.sh
+++ b/paper/scripts/slothy_dilithium_ntt_a55.sh
@@ -17,6 +17,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_dilithium_ntt_a72.sh
+++ b/paper/scripts/slothy_dilithium_ntt_a72.sh
@@ -17,6 +17,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_fft.sh
+++ b/paper/scripts/slothy_fft.sh
@@ -15,6 +15,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_kyber_ntt_a55.sh
+++ b/paper/scripts/slothy_kyber_ntt_a55.sh
@@ -17,6 +17,10 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
+
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_kyber_ntt_a72.sh
+++ b/paper/scripts/slothy_kyber_ntt_a72.sh
@@ -17,6 +17,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_ntt_helium.py
+++ b/paper/scripts/slothy_ntt_helium.py
@@ -96,7 +96,6 @@ class Example():
         logger = logging.getLogger(self.name)
         slothy = Slothy(self.arch, self.target, logger=logger)
         slothy.load_source_from_file(self.infile_full)
-        slothy.config.with_llvm_mca = True
         self.core(slothy, *self.extra_args)
 
         if self.rename:

--- a/paper/scripts/slothy_ntt_helium.py
+++ b/paper/scripts/slothy_ntt_helium.py
@@ -65,7 +65,7 @@ class Example():
     def core(self, slothy):
         slothy.optimize()
 
-    def run(self, silent=False):
+    def run(self, silent=False, no_log=False):
         logdir = "logs"
 
         handlers = []
@@ -80,13 +80,14 @@ class Example():
             h_info.addFilter(lambda r: r.levelno == logging.INFO)
             handlers.append(h_info)
 
-        # By default, use time stamp and input file
-        file_base = os.path.basename(self.outfile_full).replace('.','_')
-        logfile = f"slothy_log_{int(time.time())}_{file_base}.log"
-        logfile = f"{logdir}/{logfile}"
-        h_log = logging.FileHandler(logfile)
-        h_log.setLevel(logging.DEBUG)
-        handlers.append(h_log)
+        if no_log is False:
+            # By default, use time stamp and input file
+            file_base = os.path.basename(self.outfile_full).replace('.','_')
+            logfile = f"slothy_log_{int(time.time())}_{file_base}.log"
+            logfile = f"{logdir}/{logfile}"
+            h_log = logging.FileHandler(logfile)
+            h_log.setLevel(logging.DEBUG)
+            handlers.append(h_log)
 
         logging.basicConfig(
             level = logging.INFO,
@@ -281,6 +282,8 @@ def main():
         help=f"The list of examples to be run, comma-separated list from {all_example_names}."
     )
     parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--no-log", default=False, action='store_true',
+                        help="Don't store logfiles")
     parser.add_argument("--silent", default=False, action='store_true',
                         help="""Silent mode: Only print warnings and errors""")
 
@@ -299,7 +302,7 @@ def main():
                 break
         if ex == None:
             raise Exception(f"Could not find example {name} (known: {list(e.name for e in examples)}")
-        ex.run(silent=silent)
+        ex.run(silent=silent, no_log=args.no_log)
 
     for e in todo:
         for _ in range(iterations):

--- a/paper/scripts/slothy_ntt_helium.sh
+++ b/paper/scripts/slothy_ntt_helium.sh
@@ -13,6 +13,9 @@ ARGS=""
 if [ "$SILENT" = "Y" ]; then
     ARGS="$ARGS --silent"
 fi
+if [ "$NO_LOG" = "Y" ]; then
+    ARGS="$ARGS --no-log"
+fi
 
 export PYTHONPATH=../../
 

--- a/paper/scripts/slothy_sqmag.sh
+++ b/paper/scripts/slothy_sqmag.sh
@@ -12,6 +12,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/paper/scripts/slothy_sqmag.sh
+++ b/paper/scripts/slothy_sqmag.sh
@@ -37,7 +37,6 @@ for uarch in M55 M85; do for i in 1 2 4; do
       -c sw_pipelining.enabled=True                                                     \
       -c sw_pipelining.unroll=$i                                                        \
       -c constraints.stalls_first_attempt=1                                             \
-      -c with_llvm_mca                                                                  \
       -c timeout=$((10*$i))                                                             \
       -c /sw_pipelining.minimize_overlapping                                            \
       -c variable_size $SLOTHY_FLAGS $REDIRECT_OUTPUT ;

--- a/paper/scripts/slothy_x25519.sh
+++ b/paper/scripts/slothy_x25519.sh
@@ -17,6 +17,9 @@ LOG_DIR=logs
 mkdir -p $LOG_DIR
 
 REDIRECT_OUTPUT="--log --logdir=${LOG_DIR}"
+if [ "$NO_LOG" = "Y" ]; then
+    REDIRECT_OUTPUT=""
+fi
 if [ "$SILENT" = "Y" ]; then
     REDIRECT_OUTPUT="${REDIRECT_OUTPUT} --silent"
 fi

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -1585,9 +1585,14 @@ class SlothyBase(LockAttributes):
 
     def _extract_kernel_input_output(self):
         dfg_log = self.logger.getChild("kernel_input_output")
+
+        conf = self.config.copy()
+        conf.outputs = list(map(lambda o: self._result.output_renamings.get(o, o),
+                                       conf.outputs))
+
         self._result.kernel_input_output = list(\
             DFG(self._result.code_raw, dfg_log,
-                DFGConfig(self.config,inputs_are_outputs=True)).inputs)
+                DFGConfig(conf,inputs_are_outputs=True)).inputs)
 
     def _extract_code(self):
 

--- a/slothy/core/dataflow.py
+++ b/slothy/core/dataflow.py
@@ -755,8 +755,10 @@ class DataFlowGraph:
         # information on the type of `const` -- it could be either a GPR or a vector.
         if num_valid_candidates > 1:
             cnames = list(map(lambda c: type(c).__name__,candidates))
-            raise DataFlowGraphException(f"Cannot unambiguously choose between {cnames} "\
-                            f"in {candidates} -- need typing information")
+            self.logger.error("Source line %s can be parsed in multiple ways:", sourceline)
+            for c in candidates:
+                self.logger.error("* %s", c)
+            raise DataFlowGraphException(f"Parsing failure during type checking")
         # Add the single valid candidate parsing to the CFG
         self._add_node(valid_candidates[0])
 

--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -325,6 +325,8 @@ class Heuristics():
         c.inputs_are_outputs = True
         result = Heuristics.optimize_binsearch(body,logger.getChild("slothy"),c)
 
+        conf.outputs = list(map(lambda o: result.output_renamings.get(o,o), conf.outputs))
+
         num_exceptional_iterations = result.num_exceptional_iterations
         kernel = result.code
         assert SourceLine.is_source(kernel)

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -239,7 +239,9 @@ class SourceLine:
         assert SourceLine.is_source(src)
         for l in src:
             l.reduce()
-        return [ l for l in src if l.has_text() and not AsmHelper.is_alignment_directive(l) ]
+        return [ l for l in src if l.has_text() and
+                 not AsmHelper.is_alignment_directive(l) and
+                 not AsmHelper.is_allocation_directive(l) ]
 
     @staticmethod
     def log(name, s, logger=None, err=False):
@@ -509,6 +511,13 @@ class AsmHelper():
         """Checks is source line is an alignment directive `.[p2]align _`"""
         assert SourceLine.is_source_line(line)
         return AsmHelper._REGEXP_ALIGN.match(line.text) is not None
+
+    @staticmethod
+    def is_allocation_directive(line):
+        """Checks is source line is an allocation directive. """
+        assert SourceLine.is_source_line(line)
+        return (AsmAllocation.is_allocation(line) or
+                AsmAllocation.is_deallocation(line))
 
     @staticmethod
     def extract(source, lbl_start=None, lbl_end=None):

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -87,7 +87,7 @@ def add_st_hazard(slothy):
     def is_vec_st_st_pair(inst_a, inst_b):
         return inst_a.inst.is_vector_store() and inst_b.inst.is_vector_store()
 
-    for t0, t1 in slothy.get_inst_pairs(is_vec_st_st_pair):
+    for t0, t1 in slothy.get_inst_pairs(cond=is_vec_st_st_pair):
         if t0.is_locked and t1.is_locked:
             continue
         slothy._Add( t0.cycle_start_var != t1.cycle_start_var + 1 )

--- a/slothy/targets/arm_v81m/cortex_m55r1.py
+++ b/slothy/targets/arm_v81m/cortex_m55r1.py
@@ -83,7 +83,7 @@ def _add_st_ld_hazard(slothy):
         return True
 
     slothy._model.st_ld_hazard_vars = {}
-    for t_st, t_ld in slothy.get_inst_pairs(is_st_ld_pair):
+    for t_st, t_ld in slothy.get_inst_pairs(cond=is_st_ld_pair):
         if t_st.is_locked and t_ld.is_locked:
             continue
         if slothy.config.constraints.st_ld_hazard:

--- a/slothy/targets/arm_v81m/cortex_m85r1.py
+++ b/slothy/targets/arm_v81m/cortex_m85r1.py
@@ -77,17 +77,19 @@ class ExecutionUnit(Enum):
 # Opaque function called by SLOTHY to add further microarchitecture-
 # specific constraints which are not encapsulated by the general framework.
 def add_further_constraints(slothy):
-    for t0, t1 in slothy.get_inst_pairs():
-        for t2, t3 in slothy.get_inst_pairs():
-            if (not t0.inst.is_load_store_instruction() and
-                t1.inst.is_vector_load()                and
-                t2.inst.is_vector_store()               and
-                t3.inst.is_vector_load()):
-                b = [ slothy._NewBoolVar("") for _ in range(0,3) ]
-                slothy._AddAtLeastOne(b)
-                slothy._Add(t1.program_start_var != t0.program_start_var + 1).OnlyEnforceIf(b[0])
-                slothy._Add(t2.program_start_var != t1.program_start_var + 1).OnlyEnforceIf(b[1])
-                slothy._Add(t3.program_start_var != t2.program_start_var + 1).OnlyEnforceIf(b[2])
+    t0_t1 = slothy.get_inst_pairs(
+            cond_fst=lambda t: not t.inst.is_load_store_instruction(),
+            cond_snd=lambda t: t.inst.is_vector_load())
+    t2_t3 = slothy.get_inst_pairs(
+            cond_fst=lambda t: t.inst.is_vector_store(),
+            cond_snd=lambda t: t.inst.is_vector_load())
+    for t0, t1 in t0_t1:
+        for t2, t3 in t2_t3:
+            b = [ slothy._NewBoolVar("") for _ in range(0,3) ]
+            slothy._AddAtLeastOne(b)
+            slothy._Add(t1.program_start_var != t0.program_start_var + 1).OnlyEnforceIf(b[0])
+            slothy._Add(t2.program_start_var != t1.program_start_var + 1).OnlyEnforceIf(b[1])
+            slothy._Add(t3.program_start_var != t2.program_start_var + 1).OnlyEnforceIf(b[2])
 
 
     for t0, t1 in slothy.get_inst_pairs():


### PR DESCRIPTION
To make sure all examples still parse correctly. 
Actual optimization takes too long, but at least we catch some regressions related to parsinge/etc.