### PR TITLE
Make the renaming of reserved registers configurable

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -2636,6 +2636,7 @@ class x_stp(Stp_X): # pylint: disable=missing-docstring,invalid-name
         obj.increment = None
         obj.pre_index = None
         obj.addr = obj.args_in[0]
+        return obj
 
     def write(self):
         # For now, assert that no fixup has happened


### PR DESCRIPTION
This PR introduces the config option `reserved_regs_are_locked`. When set (default), it means that reserved registers are treated as locked, that is, existing uses will not be renamed. When unset, existing used of reserved registers may (in fact, will) be renamed.

More details in `config.py`.

Fixes: #49 