### PR TITLE
Add support for vmull2, ngc and sbcs with xzr right-op-input and xzr output

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -1651,6 +1651,12 @@ class neg(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-n
     inputs = ["Xa"]
     outputs = ["Xd"]
 
+class ngc_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
+    pattern = "ngc <Xd>, xzr"
+    inputs = []
+    outputs = ["Xd"]
+    dependsOnFlags=True
+
 class adds(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
     pattern = "adds <Xd>, <Xa>, <imm>"
     inputs = ["Xa"]
@@ -1697,6 +1703,13 @@ class sbcs_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,inv
     pattern = "sbcs <Xd>, <Xa>, xzr"
     inputs = ["Xa"]
     outputs = ["Xd"]
+    modifiesFlags=True
+    dependsOnFlags=True
+
+class sbcs_zero_to_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
+    pattern = "sbcs xzr, <Xa>, xzr"
+    inputs = ["Xa"]
+    outputs = []
     modifiesFlags=True
     dependsOnFlags=True
 
@@ -2338,6 +2351,11 @@ class vdup(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
 
 class vmull(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
     pattern = "umull <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+class vmull2(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
+    pattern = "umull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
     outputs = ["Vd"]
 

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -108,7 +108,8 @@ execution_units = {
      vshli, vshrn)            : ExecutionUnit.V1(),
     vusra                     : ExecutionUnit.V1(),
     AESInstruction            : ExecutionUnit.V0(),
-    (vmul, Vmlal, vmull)      : ExecutionUnit.V0(),
+    (vmul, Vmlal, vmull,
+     vmull2)                  : ExecutionUnit.V0(),
     AArch64NeonLogical        : ExecutionUnit.V(),
     (AArch64BasicArithmetic,
      AArch64ConditionalSelect,
@@ -143,7 +144,7 @@ inverse_throughput = {
      vshli, vshrn)             : 1,
     (vmul)                     : 2,
     vusra                      : 1,
-    (Vmlal, vmull)             : 1,
+    (Vmlal, vmull, vmull2)     : 1,
     (AArch64BasicArithmetic,
      AArch64ConditionalSelect,
      AArch64ConditionalCompare,
@@ -176,7 +177,7 @@ default_latencies = {
     (vmovi)                   : 2,
     (vmul)                    : 5,
     vusra                     : 4, # TODO: Add fwd path
-    (Vmlal, vmull)            : 4, # TODO: Add fwd path
+    (Vmlal, vmull, vmull2)    : 4, # TODO: Add fwd path
     (vuxtl, vshl, vshl_d,
      vshli, vshrn)            : 2,
     (AArch64BasicArithmetic,


### PR DESCRIPTION
This is a simple patch that adds support for three instructions: vmull2, ngc and sbcs with xzr right-op-input and xzr output.