### PR TITLE
Add support for vmull2, ngc xzr sbcs xzrs, sbcs xzrs and cmn

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -1651,6 +1651,12 @@ class neg(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-n
     inputs = ["Xa"]
     outputs = ["Xd"]
 
+class ngc_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
+    pattern = "ngc <Xd>, xzr"
+    inputs = []
+    outputs = ["Xd"]
+    dependsOnFlags=True
+
 class adds(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
     pattern = "adds <Xd>, <Xa>, <imm>"
     inputs = ["Xa"]
@@ -1700,6 +1706,13 @@ class sbcs_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,inv
     modifiesFlags=True
     dependsOnFlags=True
 
+class sbcs_zero_to_zero(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
+    pattern = "sbcs xzr, <Xa>, xzr"
+    inputs = ["Xa"]
+    outputs = []
+    modifiesFlags=True
+    dependsOnFlags=True
+
 class sbc(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
     pattern = "sbc <Xd>, <Xa>, <Xb>"
     inputs = ["Xa", "Xb"]
@@ -1722,6 +1735,12 @@ class adcs_zero_r(AArch64BasicArithmetic): # pylint: disable=missing-docstring,i
 class adcs_zero_l(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
     pattern = "adcs <Xd>, xzr, <Xb>"
     inputs = ["Xb"]
+    outputs = ["Xd"]
+    modifiesFlags=True
+    dependsOnFlags=True
+
+class adcs_zero2(AArch64BasicArithmetic): # pylint: disable=missing-docstring,invalid-name
+    pattern = "adcs <Xd>, xzr, xzr"
     outputs = ["Xd"]
     modifiesFlags=True
     dependsOnFlags=True
@@ -1962,6 +1981,11 @@ class cset(AArch64ConditionalSelect): # pylint: disable=missing-docstring,invali
     pattern = "cset <Xd>, <flag>"
     outputs = ["Xd"]
     dependsOnFlags=True
+
+class cmn(AArch64ConditionalSelect): # pylint: disable=missing-docstring,invalid-name
+    pattern = "cmn <Xd>, <Xe>"
+    inputs = ["Xd", "Xe"]
+    modifiesFlags=True
 
 class cmn_imm(AArch64ConditionalSelect): # pylint: disable=missing-docstring,invalid-name
     pattern = "cmn <Xd>, <imm>"
@@ -2338,6 +2362,11 @@ class vdup(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
 
 class vmull(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
     pattern = "umull <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+class vmull2(AArch64Instruction): # pylint: disable=missing-docstring,invalid-name
+    pattern = "umull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
     outputs = ["Vd"]
 

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -113,7 +113,7 @@ execution_units = {
         Ldr_Q,
         Str_Q,
         q_ldr1_stack, Q_Ld2_Lane_Post_Inc,
-        vmull, vmlal, vushr, vusra
+        vmull, vmull2, vmlal, vushr, vusra
     ): [[ExecutionUnit.VEC0, ExecutionUnit.VEC1]],  # these instructions use both VEC0 and VEC1
 
     St4 : [[ExecutionUnit.VEC0, ExecutionUnit.VEC1, ExecutionUnit.SCALAR_LOAD,
@@ -166,15 +166,15 @@ execution_units = {
     (x_stp_with_imm_sp, w_stp_with_imm_sp, x_str_sp_imm, Str_X) : ExecutionUnit.SCALAR_STORE,
     (x_ldr_stack_imm, ldr_const, ldr_sxtw_wform, Ldr_X) : ExecutionUnit.SCALAR_LOAD,
     (umull_wform, mul_wform, umaddl_wform ): ExecutionUnit.SCALAR_MUL(),
-    ( lsr, bic, bfi, add, add_imm, add_sp_imm, add2, add_lsr, add_lsl,
-      and_imm, nop, Vins, tst_wform, movk_imm, sub, mov,
+    ( lsr, bic, bfi, add, add_imm, add_sp_imm, add2, add_lsr, add_lsl, adcs_zero2, cmn,
+      and_imm, nop, Vins, tst_wform, movk_imm, sub, sbcs_zero_to_zero, mov, ngc_zero,
       subs_wform, asr_wform, and_imm_wform, lsr_wform, eor_wform) : ExecutionUnit.SCALAR(),
 }
 
 inverse_throughput = {
     ( vadd, vsub, vmov,
       vmul, vmul_lane, vmls, vmls_lane,
-      vqrdmulh, vqrdmulh_lane, vqdmulh_lane, vmull,
+      vqrdmulh, vqrdmulh_lane, vqdmulh_lane, vmull, vmull2,
       vmlal,
       vsrshr, umov_d ) : 1,
     (trn2, trn1, ASimdCompare): 1,
@@ -193,9 +193,9 @@ inverse_throughput = {
     (ldr_sxtw_wform) : 3,
     (lsr, lsr_wform) : 1,
     (umull_wform, mul_wform, umaddl_wform) : 1,
-    (and_twoarg, and_imm, and_imm_wform, ) : 1,
-    (add, add_imm, add2, add_lsr, add_lsl, add_sp_imm) : 1,
-    (sub, subs_wform, asr_wform) : 1,
+    (and_twoarg, and_imm, and_imm_wform) : 1,
+    (add, add_imm, add2, add_lsr, add_lsl, add_sp_imm, adcs_zero2, cmn) : 1,
+    (sub, subs_wform, asr_wform, sbcs_zero_to_zero, ngc_zero) : 1,
     (bfi) : 1,
     (vshl, vshl, vushr) : 1,
     (vusra) : 1,
@@ -218,7 +218,7 @@ default_latencies = {
     (trn1, trn2, ASimdCompare): 2,
     ( vsrshr ) : 3,
     ( vmul, vmul_lane, vmls, vmls_lane,
-      vqrdmulh, vqrdmulh_lane, vqdmulh_lane, vmull,
+      vqrdmulh, vqrdmulh_lane, vqdmulh_lane, vmull, vmull2,
       vmlal) : 4,
     ( Ldr_Q, Str_Q ) : 4,
     St4 : 5,
@@ -238,7 +238,8 @@ default_latencies = {
     (umull_wform, mul_wform, umaddl_wform) : 3,
     (and_imm, and_imm_wform) : 1,
     (add2, add_lsr, add_lsl, add_sp_imm) : 2,
-    (add, add_imm, sub, subs_wform, asr_wform) : 1,
+    (add, add_imm, adcs_zero2, sub, subs_wform, asr_wform, sbcs_zero_to_zero,
+     cmn, ngc_zero) : 1,
     (bfi) : 2,
     (vshl, vushr) : 2,
     (vusra) : 3,

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -108,7 +108,8 @@ execution_units = {
      vshli, vshrn)            : ExecutionUnit.V1(),
     vusra                     : ExecutionUnit.V1(),
     AESInstruction            : ExecutionUnit.V0(),
-    (vmul, Vmlal, vmull)      : ExecutionUnit.V0(),
+    (vmul, Vmlal, vmull,
+     vmull2)                  : ExecutionUnit.V0(),
     AArch64NeonLogical        : ExecutionUnit.V(),
     (AArch64BasicArithmetic,
      AArch64ConditionalSelect,
@@ -143,7 +144,7 @@ inverse_throughput = {
      vshli, vshrn)             : 1,
     (vmul)                     : 2,
     vusra                      : 1,
-    (Vmlal, vmull)             : 1,
+    (Vmlal, vmull, vmull2)     : 1,
     (AArch64BasicArithmetic,
      AArch64ConditionalSelect,
      AArch64ConditionalCompare,
@@ -176,7 +177,7 @@ default_latencies = {
     (vmovi)                   : 2,
     (vmul)                    : 5,
     vusra                     : 4, # TODO: Add fwd path
-    (Vmlal, vmull)            : 4, # TODO: Add fwd path
+    (Vmlal, vmull, vmull2)    : 4, # TODO: Add fwd path
     (vuxtl, vshl, vshl_d,
      vshli, vshrn)            : 2,
     (AArch64BasicArithmetic,


### PR DESCRIPTION
This adds support for a few arithmetic instructions in AArch64.

The updated uarchs are Neoverse N1 and Cortex A55.