### PR TITLE
Fix bug in cross-loop dependency handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 ortools==9.7.2996
 pandas==2.1.1
 sympy==1.12

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -2020,8 +2020,9 @@ class SlothyBase(LockAttributes):
         bvars = [ self._NewBoolVar("") for _ in cb_lst ]
         self._AddExactlyOne(bvars)
 
-        if self._is_low(consumer) and self._is_high(producer):
-            raise Exception("Not yet implemented")
+        if self.config.sw_pipelining.enabled is True and \
+           self._is_low(consumer) and self._is_high(producer):
+           raise Exception("Not yet implemented")
 
         if not self.config.sw_pipelining.enabled or producer.is_virtual or consumer.is_virtual:
             for (cb, bvar) in zip(cb_lst, bvars, strict=True):


### PR DESCRIPTION
`is_low` and `is_high` are only meaningful in SW pipelining mode. Calling them in straightline mode introduces wrong assertions which have led to the x25519 script failing.

Thanks for Amin for noticing.