### PR TITLE
Allow spaces instead of commas in macro definitions and invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__
+venv/

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -789,7 +789,7 @@ class AsmMacro():
         for arg in self.args:
             arg_regexps.append(rf"\s*(?P<{arg}>[^,]+)\s*")
 
-        macro_regexp_txt += ','.join(arg_regexps)
+        macro_regexp_txt += '(,|\s)'.join(arg_regexps)
         macro_regexp = re.compile(macro_regexp_txt)
 
         output = []
@@ -875,7 +875,7 @@ class AsmMacro():
                 if cur.tags.get("no-unfold", None) is not None:
                     continue
 
-                current_args = [ a.strip() for a in p.group("args").split(',') ]
+                current_args = [ a.strip() for a in re.split(r'\s|\,', p.group("args")) if a.strip() != ""]
                 current_macro = p.group("name")
                 current_body = []
 


### PR DESCRIPTION
The GNU as [1] allows macro definitons and invoation to separate arguments by spaces or commas. So far SLOTHY cannot handle spaces in both definitions and invocations.
This commit adds that functionality.

Here is some minimal examples for which SLOTHY currently fails:

```asm
.macro mx aa bb cc
    add \aa, \bb, \cc
.endm

.macro my aa, bb, cc
    add \aa, \bb, \cc
.endm

start:
mx x3, x1, x2
mx x4  x1  x2
my x5, x1, x2
my x6  x1  x2
end:
```

The following SLOTHY calls can be used to test:
```py
import logging
import sys
from slothy import Slothy

import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
import slothy.targets.aarch64.cortex_a55 as Target_CortexA55

logging.basicConfig(stream=sys.stdout, level=logging.INFO)

arch = AArch64_Neon
target = Target_CortexA55

slothy = Slothy(arch, target)

slothy.load_source_from_file("sample.s")
slothy.config.outputs=["x3", "x4", "x5", "x6"]

slothy.optimize(start="start", end="end")
slothy.write_source_to_file("opt.s")
```

[1] https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_node/as_107.html