### PR TITLE
Allow setting `functional_only = False`

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -973,10 +973,8 @@ class Config(NestedPrint, LockAttributes):
             self._allow_renaming = val
         @functional_only.setter
         def functional_only(self,val):
-            if not val:
-                return
-            self._model_latencies = False
-            self._model_functional_units = False
+            self._model_latencies = val is False
+            self._model_functional_units = val is False
 
     class Hints(NestedPrint, LockAttributes):
         """Subconfiguration for solver hints"""


### PR DESCRIPTION
`config.constraints.functional_only` is a wrapper property around `model_latencies` and `model_functional_units`. However, previously it would only be supported to set `functional_only = True`, in which case both `model_latencies` and `model_functional_units` would be set to `False` -- attempting `functional_only = False`, in turn, would be silently ignored, which is certainly not desired.

This commit modifies the `functional_only` setter to always set both `model_functional_units` and `model_latencies` to the negation of the value that's being specified.