### PR TITLE
Don't trim comments to the right

### DIFF
--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -83,7 +83,7 @@ class SourceLine:
         return s
 
     def _strip_comments(self):
-        self._comments = list(map(str.strip, self._comments))
+        self._comments = list(map(str.lstrip, self._comments))
 
     def _trim_comments(self):
         self._strip_comments()


### PR DESCRIPTION
We use fixed-width comments to align `// gap` annotations and the `// ...` position-visualization. With the previous behaviour of `SourceLine._strip_comments()`, the right-padding of the `gap` comment would be removed, leading to misaligned output.

This commit modifies comment trimming to use lstrip() only.