### PR TITLE
Change default of visualize_expected_performance to True

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -1088,7 +1088,7 @@ class Config(NestedPrint, LockAttributes):
         # Visualization
         self.indentation = 8
         self.visualize_reordering = True
-        self.visualize_expected_performance = False
+        self.visualize_expected_performance = True
 
         self.placeholder_char = '.'
         self.early_char = 'e'


### PR DESCRIPTION

The visualize_expected_performance option introduced in https://github.com/slothy-optimizer/slothy/commit/d2fcecad5a313a59de585b3f4350902536f71028, allows to switch from the `// gap` output, to a visualization of the performance (see examples below). 
I think the visualization is strictly better and should be enabled by default. 
What do you think @hanno-becker and @dop-amin?


gap output: 
```
                                                // Instructions:    20
                                                // Expected cycles: 28
                                                // Expected IPC:    0.71
                                                //
                                                // Cycle bound:     28.0
                                                // IPC bound:       0.71
                                                //
                                                // Wall time:     0.18s
                                                // User time:     0.18s
                                                //
                                                // ----- original position ----->
                                                // 0                        25
                                                // |------------------------|----
        ldr q4, [x1, #0]                        // *.............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        ldr q19, [x0, #16]                      // ...*..........................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        ldr q22, [x0, #48]                      // .....*........................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        sqrdmulh v6.8H, v19.8H, v4.H[1]         // .......*......................
        // gap                                  // ..............................
        mul v12.8H, v19.8H, v4.H[0]             // ......*.......................
        // gap                                  // ..............................
        ldr q2, [x2, #0]                        // .*............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        sqrdmulh v29.8H, v22.8H, v4.H[1]        // ............*.................
        // gap                                  // ..............................
        mul v25.8H, v22.8H, v4.H[0]             // ...........*..................
        // gap                                  // ..............................
        mls v12.8H, v6.8H, v2.H[0]              // ........*.....................
        // gap                                  // ..............................
        ldr q26, [x0]                           // ..*...........................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        mls v25.8H, v29.8H, v2.H[0]             // .............*................
        // gap                                  // ..............................
        ldr q21, [x0, #32]                      // ....*.........................
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        sub v4.8H, v26.8H, v12.8H               // .........*....................
        // gap                                  // ..............................
        add v29.8H, v26.8H, v12.8H              // ..........*...................
        // gap                                  // ..............................
        sub v18.8H, v21.8H, v25.8H              // ..............*...............
        // gap                                  // ..............................
        str q4, [x0, #16]                       // .................*............
        // gap                                  // ..............................
        add v7.8H, v21.8H, v25.8H               // ...............*..............
        // gap                                  // ..............................
        str q18, [x0, #48]                      // ...................*..........
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        str q29, [x0], #4*16                    // ................*.............
        // gap                                  // ..............................
        // gap                                  // ..............................
        // gap                                  // ..............................
        str q7, [x0, #-32]                      // ..................*...........
        // gap                                  // ..............................
```
        
isualization: 
```
                                                // Instructions:    20
                                                // Expected cycles: 28
                                                // Expected IPC:    0.71
                                                //
                                                // Cycle bound:     28.0
                                                // IPC bound:       0.71
                                                //
                                                // Wall time:     0.22s
                                                // User time:     0.22s
                                                //
                                                // ----- cycle (expected) ------>
                                                // 0                        25
                                                // |------------------------|----
        ldr q9, [x1, #0]                        // *.............................
        ldr q11, [x0, #16]                      // ..*...........................
        ldr q10, [x0, #48]                      // ....*.........................
        mul v26.8H, v11.8H, v9.H[0]             // ......*.......................
        sqrdmulh v11.8H, v11.8H, v9.H[1]        // .......*......................
        mul v15.8H, v10.8H, v9.H[0]             // ........*.....................
        sqrdmulh v9.8H, v10.8H, v9.H[1]         // .........*....................
        ldr q10, [x2, #0]                       // ..........*...................
        ldr q13, [x0]                           // ............*.................
        mls v26.8H, v11.8H, v10.H[0]            // ..............*...............
        mls v15.8H, v9.8H, v10.H[0]             // ...............*..............
        ldr q9, [x0, #32]                       // ................*.............
        sub v11.8H, v13.8H, v26.8H              // ..................*...........
        add v10.8H, v13.8H, v26.8H              // ...................*..........
        sub v26.8H, v9.8H, v15.8H               // ....................*.........
        str q11, [x0, #16]                      // .....................*........
        add v9.8H, v9.8H, v15.8H                // ......................*.......
        str q10, [x0], #4*16                    // .......................*......
        str q9, [x0, #-32]                      // .........................*....
        str q26, [x0, #-16]                     // ...........................*..
```
        