### PR TITLE
Extend support for symbolic assembly via spilling

### DIFF
--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -258,7 +258,8 @@ class Heuristics():
 
         logger.info(f"Minimum number of stalls: {min_stalls}")
 
-        if conf.has_objective is False:
+        # Spill minimization is integrated into the stall minimization objective
+        if conf.has_objective is False or conf.constraints.minimize_spills is True:
             return core.result
 
         logger.info("Optimize again with minimal number of %d stalls, with objective...",

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -63,6 +63,11 @@ class RegisterType(Enum):
 
     @cache
     @staticmethod
+    def spillable(reg_type):
+        return reg_type in [RegisterType.GPR, RegisterType.NEON]
+
+    @cache
+    @staticmethod
     def list_registers(reg_type, only_extra=False, only_normal=False, with_variants=False):
         """Return the list of all registers of a given type"""
 
@@ -3024,6 +3029,15 @@ class cmge(ASimdCompare): # pylint: disable=missing-docstring,invalid-name
     pattern = "cmge <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
     outputs = ["Vd"]
+
+
+class Stack:
+    def spill(reg, loc):
+        # TODO: Use store instruction
+        return f"str {reg}, [sp, #STACK_LOC_{loc}]"
+    def restore(reg, loc):
+        # TODO: Use load instruction
+        return  f"ldr {reg}, [sp, #STACK_LOC_{loc}]"
 
 # In a pair of vins writing both 64-bit lanes of a vector, mark the
 # target vector as output rather than input/output. This enables further


### PR DESCRIPTION
SLOTHY has long supported assembly which uses symbolic register names instead of architectural ones. This commit improves the compatibility of this feature with both (a) complex workloads using numerous symbolic registers, and (b) architectures offering only a small register file, by adding experimental support for a simplified form of register spilling.