### PR TITLE
Add config obective_lower_bound

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -451,6 +451,11 @@ class Config(NestedPrint, LockAttributes):
         return self._objective_precision
 
     @property
+    def objective_lower_bound(self):
+        """A lower bound for the objective at which to stop the search."""
+        return self._objective_lower_bound
+
+    @property
     def has_objective(self):
         """Indicates whether a different objective than minimization of stalls
         has been registered."""
@@ -1143,6 +1148,7 @@ class Config(NestedPrint, LockAttributes):
         self._retry_timeout = None
         self._ignore_objective = False
         self._objective_precision = 0
+        self._objective_lower_bound = None
 
         # Visualization
         self.indentation = 8
@@ -1280,6 +1286,9 @@ class Config(NestedPrint, LockAttributes):
     @objective_precision.setter
     def objective_precision(self, val):
         self._objective_precision = val
+    @objective_lower_bound.setter
+    def objective_lower_bound(self, val):
+        self._objective_lower_bound = val
     @absorb_spills.setter
     def absorb_spills(self, val):
         self._absorb_spills = val

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -3256,7 +3256,7 @@ class SlothyBase(LockAttributes):
                 name = "minimize iteration overlapping"
             elif self.config.constraints.minimize_spills:
                 name = "minimize spills"
-                minlist = [self._model.spill_vars]
+                minlist = self._model.spill_vars
             elif self.config.constraints.maximize_register_lifetimes:
                 name = "maximize register lifetimes"
                 maxlist = [ v for t in self._get_nodes(allnodes=True)

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -3392,11 +3392,19 @@ class SlothyBase(LockAttributes):
                 if cur - bound <= self.config.constraints.stalls_precision:
                     self.logger.info("Closer than %d stalls to theoretical optimum... stop", prec)
                     return True
+                if self.config.objective_lower_bound is not None and \
+                   cur <= self.config.objective_lower_bound:
+                    self.logger.info("Reached user-defined objective_lower_bound ... stop", prec)
+                    return True
             elif self._model.objective_name != "no objective":
                 prec = self.config.objective_precision
                 if bound > 0 and abs(1 - (cur / bound)) < prec:
                     self.logger.info("Closer than %d%% to theoretical optimum... stop",
                                         int(prec*100))
+                    return True
+                if self.config.objective_lower_bound is not None and \
+                   cur <= self.config.objective_lower_bound:
+                    self.logger.info("Reached user-defined objective_lower_bound ... stop", prec)
                     return True
             return False
 

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -3394,7 +3394,7 @@ class SlothyBase(LockAttributes):
                     return True
                 if self.config.objective_lower_bound is not None and \
                    cur <= self.config.objective_lower_bound:
-                    self.logger.info("Reached user-defined objective_lower_bound ... stop", prec)
+                    self.logger.info("Reached user-defined objective_lower_bound ... stop")
                     return True
             elif self._model.objective_name != "no objective":
                 prec = self.config.objective_precision
@@ -3404,7 +3404,7 @@ class SlothyBase(LockAttributes):
                     return True
                 if self.config.objective_lower_bound is not None and \
                    cur <= self.config.objective_lower_bound:
-                    self.logger.info("Reached user-defined objective_lower_bound ... stop", prec)
+                    self.logger.info("Reached user-defined objective_lower_bound ... stop")
                     return True
             return False
 


### PR DESCRIPTION
Sometimes one already knows a lower bound for an objective (spills, stalls) and searching longer is a waste of compute. 
This PR adds an option to SLOTHY to provide that lower bound at which SLOTHY stops optimizing.

Usage example (for spill code generation): 
```
        slothy.config.objective_lower_bound = 7
        slothy.config.inputs_are_outputs = True
        slothy.config.constraints.functional_only = True
        slothy.config.constraints.allow_spills = True
        slothy.config.constraints.minimize_spills = True
        slothy.config.constraints.allow_reordering = False
        slothy.optimize(start="layer1234_start", end="layer1234_end")
```

It also fixes a small error in core.py line 3259 that lead to the following error: 
```
Traceback (most recent call last):
  File "/home/mjk/git/pqmx/slothy/example.py", line 2405, in <module>
    main()
  File "/home/mjk/git/pqmx/slothy/example.py", line 2399, in main
    run_example(e, debug=args.debug, dry_run=args.dry_run,
  File "/home/mjk/git/pqmx/slothy/example.py", line 2395, in run_example
    ex.run(**kwargs)
  File "/home/mjk/git/pqmx/slothy/example.py", line 163, in run
    self.core(slothy, *self.extra_args)
  File "/home/mjk/git/pqmx/slothy/example.py", line 1919, in core
    slothy.optimize(start="layer1234_start", end="layer1234_end")
  File "/home/mjk/git/pqmx/slothy/slothy/core/slothy.py", line 261, in optimize
    early, core, late, num_exceptional = Heuristics.periodic(body, logger, c)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjk/git/pqmx/slothy/slothy/core/heuristics.py", line 325, in periodic
    res = Heuristics.linear( body, logger=logger, conf=conf)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjk/git/pqmx/slothy/slothy/core/heuristics.py", line 402, in linear
    return Heuristics.optimize_binsearch(body,logger.getChild("slothy"), conf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjk/git/pqmx/slothy/slothy/core/heuristics.py", line 137, in optimize_binsearch
    return Heuristics.optimize_binsearch_external(source, logger, conf,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjk/git/pqmx/slothy/slothy/core/heuristics.py", line 181, in optimize_binsearch_external
    if not core.optimize(source):
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjk/git/pqmx/slothy/slothy/core/core.py", line 1470, in optimize
    self._add_objective()
  File "/home/mjk/git/pqmx/slothy/slothy/core/core.py", line 3292, in _add_objective
    self._model.cp_model.Minimize(cp_model.LinearExpr.Sum(minlist))
  File "/home/mjk/git/pqmx/slothy/venv/lib/python3.12/site-packages/ortools/sat/python/cp_model.py", line 2377, in Minimize
    self._SetObjective(obj, minimize=True)
  File "/home/mjk/git/pqmx/slothy/venv/lib/python3.12/site-packages/ortools/sat/python/cp_model.py", line 2373, in _SetObjective
    raise TypeError("TypeError: " + str(obj) + " is not a valid objective")
TypeError: TypeError: [(0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1), (0..1)] is not a valid objective
```