### PR TITLE
Add equivalence tester

### DIFF
--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -1,0 +1,33 @@
+name: Setup ubuntu
+description: Setup ubuntu
+
+inputs:
+  packages:
+    description: Space-separated list of additional packages to install
+    required: false
+    default: 'llvm llvm-runtime'
+
+runs:
+  using: composite
+  steps:
+    - name: Update package repository
+      shell: bash
+      run: |
+        sudo apt-get update
+    - name: Install base packages
+      shell: bash
+      run: |
+        sudo apt-get install python3-venv python3-pip make -y
+    - name: Install additional packages
+      if: ${{ inputs.packages != ''}}
+      shell: bash
+      run: |
+        sudo apt-get install ${{ inputs.packages }} -y
+    - name: Setup Python venv
+      shell: bash
+      run: |
+        python3 -m venv venv
+        source venv/bin/activate
+        python3 -m pip install -r requirements.txt
+        deactivate
+        echo "$(pwd)/venv/bin/" >> "$GITHUB_PATH"

--- a/.github/workflows/test_basic.yaml
+++ b/.github/workflows/test_basic.yaml
@@ -12,16 +12,12 @@ jobs:
             github.event.pull_request.user.login == 'mkannwischer'
             }}
     runs-on: ubuntu-latest
-    strategy: 
-      matrix:      
+    strategy:
+      matrix:
         target: [slothy.targets.arm_v7m.cortex_m7,slothy.targets.arm_v81m.cortex_m55r1, slothy.targets.arm_v81m.cortex_m85r1, slothy.targets.aarch64.cortex_a55, slothy.targets.aarch64.cortex_a72_frontend, slothy.targets.aarch64.apple_m1_firestorm_experimental, slothy.targets.aarch64.apple_m1_icestorm_experimental]
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         python3 example.py --dry-run --only-target=${{ matrix.target }}
@@ -34,11 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run tutorial
       run: |
         (cd tutorial && ./tutorial_all.sh)
@@ -51,11 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         python3 example.py --examples simple0,simple1,simple0_loop,simple1_loop
@@ -68,11 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         python3 example.py --examples ntt_kyber_1_23_45_67_m55,ntt_dilithium_12_34_56_78_m55 --timeout=300
@@ -85,11 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         python3 example.py --examples ntt_kyber_123_4567_a55,ntt_dilithium_123_45678_a55 --timeout=300
@@ -102,11 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         (cd paper/scripts && NO_LOG=Y ./slothy_sqmag.sh)
@@ -119,11 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python dependencies
-      run: |
-        python3 -m venv venv
-        ./venv/bin/python3 -m pip install -r requirements.txt
-        echo BASH_ENV="./venv/bin/activate" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-ubuntu
     - name: Run examples
       run: |
         (cd paper/scripts && NO_LOG=Y ./slothy_fft.sh)

--- a/example.py
+++ b/example.py
@@ -656,6 +656,24 @@ class Armv7mExample0(Example):
         slothy.config.inputs_are_outputs = True
         slothy.optimize(start="start", end="end")
 
+class Armv7mExample0Func(Example):
+    def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
+        name = "armv7m_simple0_func"
+        infile = name
+
+        if var != "":
+            name += f"_{var}"
+            infile += f"_{var}"
+        name += f"_{target_label_dict[target]}"
+
+        super().__init__(infile, name, rename=True, arch=arch, target=target)
+
+    def core(self,slothy):
+        slothy.config.variable_size=True
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize(start="start", end="end")
+        slothy.global_selftest("my_func", {"r0": 1024 })
+
 class Armv7mLoopSubs(Example):
     def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
         name = "loop_subs"
@@ -688,7 +706,7 @@ class Armv7mLoopCmp(Example):
         slothy.config.variable_size=True
         slothy.config.outputs = ["r6"]
         slothy.optimize_loop("start")
-        
+
 class Armv7mLoopVmovCmp(Example):
     def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
         name = "loop_vmov_cmp"
@@ -720,12 +738,13 @@ class AArch64IfElse(Example):
 
     def core(self,slothy):
         slothy.optimize()
-        
+
 class ntt_kyber_123_4567(Example):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55, timeout=None):
         name = "ntt_kyber_123_4567"
         infile = name
 
+        self.var = var
         if var != "":
             name += f"_{var}"
             infile += f"_{var}"
@@ -744,6 +763,10 @@ class ntt_kyber_123_4567(Example):
         slothy.config.constraints.stalls_first_attempt = 64
         slothy.optimize_loop("layer123_start")
         slothy.optimize_loop("layer4567_start")
+        # Build + emulate entire function to test that behaviour has not changed
+        if self.var == "":
+            slothy.global_selftest("ntt_kyber_123_4567",
+                                   {"x0": 1024, "x1": 1024, "x3": 1024, "x4": 1024, "x5": 1024})
 
 class intt_kyber_123_4567(Example):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55, timeout=None):
@@ -1226,7 +1249,7 @@ class intt_dilithium_123_45678(Example):
         slothy.config.constraints.stalls_first_attempt = 110
         slothy.optimize_loop("layer123_start")
 
-        
+
 
 
 class ntt_dilithium_123(Example):
@@ -1349,7 +1372,7 @@ class intt_dilithium_1234_5678(Example):
         slothy.optimize_loop("layer5678_start")
 
         slothy.config = conf.copy()
-        
+
         if self.timeout is not None:
             slothy.config.timeout = self.timeout // 12
 
@@ -1366,7 +1389,7 @@ class intt_dilithium_1234_5678(Example):
         slothy.config.split_heuristic_stepsize = 0.1
         slothy.config.constraints.stalls_first_attempt = 14
         slothy.optimize_loop("layer1234_start")
-            
+
 
 class ntt_dilithium_1234(Example):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA72):
@@ -1513,6 +1536,7 @@ def main():
 
                 # Armv7m examples
                  Armv7mExample0(),
+                 Armv7mExample0Func(),
 
                 # Loop examples
                  AArch64LoopSubs(),

--- a/examples/naive/aarch64/ntt_kyber_123_4567.s
+++ b/examples/naive/aarch64/ntt_kyber_123_4567.s
@@ -23,8 +23,13 @@
 /// SOFTWARE.
 ///
 
+// Commented out for simple standalone emulation not
+// requiring correct constant data
+//
+// Should be commented when used.
+//
 // Needed to provide ASM_LOAD directive
-#include <hal_env.h>
+// #include <hal_envh>
 
 .macro mulmodq dst, src, const, idx0, idx1
         sqrdmulh t2.8h,   \src\().8h, \const\().h[\idx1]
@@ -154,7 +159,12 @@
 .data
 .p2align 4
 roots:
-        #include "ntt_kyber_123_45_67_twiddles.s"
+// Commented out for simple standalone emulation not
+// requiring correct constant data
+//
+// Should be commented when used.
+//
+//        #include "ntt_kyber_123_45_67_twiddles.s"
 
         in      .req x0
         inp     .req x1
@@ -223,9 +233,14 @@ ntt_kyber_123_4567:
 _ntt_kyber_123_4567:
         push_stack
 
-        ASM_LOAD(r_ptr0, roots)
-        ASM_LOAD(r_ptr1, roots_l56)
-        ASM_LOAD(xtmp, const_addr)
+// Commented out for simple standalone emulation not
+// requiring correct constant data.
+//
+// Should be commented when used.
+//
+//        ASM_LOAD(r_ptr0, roots)
+//        ASM_LOAD(r_ptr1, roots_l56)
+//        ASM_LOAD(xtmp, const_addr)
 
         ld1 {consts.8h}, [xtmp]
 

--- a/examples/naive/armv7m/armv7m_simple0_func.s
+++ b/examples/naive/armv7m/armv7m_simple0_func.s
@@ -1,0 +1,20 @@
+.syntax unified
+//.cpu cortex-m4 // llvm-mc does not like this...
+//.thumb // unicorn seems to get confused by this...
+
+.align 2
+.global my_func
+// .type my_func, %function // llvm-mc does not like this...
+my_func:
+  push {r4-r11, lr}
+
+start:
+ldr r8, [r0, #4]
+add r8, r2, r8
+eor.w r8, r8, r3
+smlabt r3, r2, r2, r8
+asrs r3, r3, #1
+str r3, [r0, #4]
+end:
+
+  pop {r4-r11, pc}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.26.4
 ortools==9.7.2996
 pandas==2.1.1
 sympy==1.12
+unicorn==2.1.1

--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -122,8 +122,8 @@ class Config(NestedPrint, LockAttributes):
           equivalence-check the loop-form (including the compare+branch instructions
           at the loop boundary) rather than the unrolled code.
 
-        DEPENDENCY: To run this, you need `llvm-mc` the binary in your path or configured
-        as via `llvm_mc_binary`, and `unicorn-engine` Python bindings setup.
+        DEPENDENCY: To run this, you need `llvm-nm`, `llvm-readobj`, `llvm-mc`
+                    in your PATH. Those are part of a standard LLVM setup.
 
         NOTE: This is so far implemented as a repeated randomized test -- nothing clever.
         """
@@ -416,8 +416,8 @@ class Config(NestedPrint, LockAttributes):
         """Indicates whether LLVM MCA should be run prior and after optimization
         to obtain approximate performance data based on LLVM's scheduling models.
 
-        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
-        need to be set.
+        If this is set, Config.compiler_binary need to be set, and llcm-mca in
+        your PATH.
         """
         return self._with_llvm_mca_before and self._with_llvm_mca_after
 
@@ -438,8 +438,8 @@ class Config(NestedPrint, LockAttributes):
         """Indicates whether LLVM MCA should be run prior to optimization
         to obtain approximate performance data based on LLVM's scheduling models.
 
-        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
-        need to be set.
+        If this is set, Config.compiler_binary need to be set, and llcm-mca in
+        your PATH.
         """
         return self._with_llvm_mca_before
 
@@ -448,8 +448,8 @@ class Config(NestedPrint, LockAttributes):
         """Indicates whether LLVM MCA should be run after optimization
         to obtain approximate performance data based on LLVM's scheduling models.
 
-        If this is set, both Config.llvm_mca_binary and Config.compiler_binary
-        need to be set.
+        If this is set, Config.compiler_binary need to be set, and llcm-mca in
+        your PATH.
         """
         return self._with_llvm_mca_after
 
@@ -468,21 +468,6 @@ class Config(NestedPrint, LockAttributes):
         This is only relevant if `with_preprocessor` or `with_llvm_mca_before`
         or `with_llvm_mca_after` are set."""
         return self._compiler_include_paths
-
-    @property
-    def llvm_mca_binary(self):
-        """The llvm-mca binary to be used for estimated performance annotations
-
-        This is only relevant if `with_llvm_mca_before` or `with_llvm_mca_after`
-        is set."""
-        return self._llvm_mca_binary
-
-    @property
-    def llvm_mc_binary(self):
-        """The llvm-mc binary to be used for assembling output data
-
-        This is only relevant if `selftest` is set."""
-        return self._llvm_mc_binary
 
     @property
     def timeout(self):
@@ -1228,8 +1213,6 @@ class Config(NestedPrint, LockAttributes):
 
         self._compiler_binary = "gcc"
         self._compiler_include_paths = None
-        self._llvm_mca_binary = "llvm-mca"
-        self._llvm_mc_binary = "llvm-mc"
 
         self.keep_tags = True
         self.inherit_macro_comments = False
@@ -1377,12 +1360,6 @@ class Config(NestedPrint, LockAttributes):
     @compiler_include_paths.setter
     def compiler_include_paths(self, val):
         self._compiler_include_paths = val
-    @llvm_mca_binary.setter
-    def llvm_mca_binary(self, val):
-        self._llvm_mca_binary = val
-    @llvm_mc_binary.setter
-    def llvm_mc_binary(self, val):
-        self._llvm_mc_binary = val
     @timeout.setter
     def timeout(self, val):
         self._timeout = val

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -27,6 +27,7 @@
 
 import logging
 import math
+import os
 import time
 
 from types import SimpleNamespace
@@ -38,7 +39,12 @@ import ortools
 from ortools.sat.python import cp_model
 
 from slothy.core.config import Config
-from slothy.helper import LockAttributes, Permutation, DeferHandler, SourceLine
+from slothy.helper import LockAttributes, Permutation, DeferHandler, SourceLine, LLVM_Mc
+
+try:
+    from unicorn import Uc
+except ImportError:
+    Uc = None
 
 from slothy.core.dataflow import DataFlowGraph as DFG
 from slothy.core.dataflow import Config as DFGConfig
@@ -818,6 +824,121 @@ class Result(LockAttributes):
             raise SlothySelfCheckException("Isomorphism between computation flow graphs: FAIL!")
         return res
 
+    def selftest(self, log):
+        """Run empirical self test, if it exists for the target architecture"""
+        if self._config.selftest is False:
+            return
+
+        if Uc is None:
+            raise SlothySelfTestException("Cannot run selftest -- unicorn-engine is not available.")
+
+        if self._config.arch.unicorn_arch is None or \
+           self._config.arch.llvm_mc_arch is None:
+            log.warning("Selftest not supported on target architecture")
+            return
+
+        log.info(f"Running selftest ({self._config.selftest_iterations} iterations)...")
+
+        address_gprs = self._config.selftest_address_gprs
+        if address_gprs is None:
+            # Try to infer which registes need to be pointers
+            log_addresses = log.getChild("infer_address_gprs")
+            tree = DFG(self._orig_code, log_addresses, DFGConfig(self.config, outputs=self.outputs))
+            # Look for load/store instructions and remember addresses
+            addresses = set()
+            for t in tree.nodes:
+                addr = getattr(t.inst, "addr", None)
+                if addr is None:
+                    continue
+                addresses.add(addr)
+
+            # For now, we don't look into increments and immedate offsets
+            # to gauge the amount of memory we actually need. Instaed, we
+            # just allocate a buffer of a configurable default size.
+            log.info(f"Inferred that the following registers seem to act as pointers: {addresses}")
+            log.info(f"Using default buffer size of {self._config.selftest_default_memory_size} bytes. "
+                     "If you want different buffer sizes, set selftest_address_gprs manually.")
+            address_gprs = { a: self._config.selftest_default_memory_size for a in addresses }
+
+        # This produces _unrolled_ code, the same that is checked in the selfcheck.
+        # The selftest should instead use the rolled form of the loop.
+        iterations = 7
+        if self.config.sw_pipelining.enabled is True:
+            old_source, new_source = self.get_fully_unrolled_loop(iterations)
+        else:
+            old_source, new_source = self.orig_code, self.code
+
+        CODE_BASE = 0x010000
+        CODE_SZ =   0x010000
+        RAM_BASE =  0x020000
+        RAM_SZ =    0x010000
+
+        regs = [r for ty in self._config.arch.RegisterType for r in \
+            self._config.arch.RegisterType.list_registers(ty)]
+
+        def run_code(code, txt=None):
+            objcode = LLVM_Mc.assemble(code, self._config.llvm_mc_binary,
+                                       self._config.arch.llvm_mc_arch,
+                                       self._config.arch.llvm_mc_attr,
+                                       log)
+
+            # Setup emulator
+            mu = Uc(self.config.arch.unicorn_arch, self.config.arch.unicorn_mode)
+            # Copy initial register contents into emulator
+            for r,v in initial_register_contents.items():
+                ur = self._config.arch.RegisterType.unicorn_reg_by_name(r)
+                if ur is None:
+                    continue
+                mu.reg_write(ur, v)
+            # Copy code into emulator
+            mu.mem_map(CODE_BASE, CODE_SZ)
+            mu.mem_write(CODE_BASE, objcode)
+            # Copy initial memory contents into emulator
+            mu.mem_map(RAM_BASE, RAM_SZ)
+            mu.mem_write(RAM_BASE, initial_memory)
+            # Run emulator
+            mu.emu_start(CODE_BASE, CODE_BASE + len(objcode))
+
+            final_register_contents = {}
+            for r in regs:
+                ur = self._config.arch.RegisterType.unicorn_reg_by_name(r)
+                if ur is None:
+                    continue
+                final_register_contents[r] = mu.reg_read(ur)
+            final_memory_contents = mu.mem_read(RAM_BASE, RAM_SZ)
+
+            return final_register_contents, final_memory_contents
+
+        for _ in range(self._config.selftest_iterations):
+            initial_memory = os.urandom(RAM_SZ)
+            cur_ram = RAM_BASE
+            # Set initial register contents arbitrarily, except for registers
+            # which must hold valid memory addresses.
+            initial_register_contents = {}
+            for r in regs:
+                initial_register_contents[r] = int.from_bytes(os.urandom(16))
+            for (reg, sz) in address_gprs.items():
+                initial_register_contents[reg] = cur_ram
+                cur_ram += sz
+
+            final_regs_old, final_mem_old = run_code(old_source, txt="old")
+            final_regs_new, final_mem_new = run_code(new_source, txt="new")
+
+            # Check if memory contents are the same
+            if final_mem_old != final_mem_new:
+                raise SlothySelfTestException(f"Selftest failed: Memory mismatch")
+
+            # Check if register contents are the same
+            regs_expected = set(self.config.outputs).union(self.config.reserved_regs)
+            # Ignore hint registers, flags and sp for now
+            regs_expected = set(filter(lambda t: t.startswith("t") is False and
+                                             t != "sp" and t != "flags", regs_expected))
+            for r in regs_expected:
+                if final_regs_old[r] != final_regs_new[r]:
+                    raise SlothySelfTestException(f"Selftest failed: Register mismatch for {r}: {hex(final_regs_old[r])} != {hex(final_regs_new[r])}")
+
+        log.info("Selftest: OK")
+
     def selfcheck_with_fixup(self, log):
         """Do selfcheck, and consider preamble/postamble fixup in case of SW pipelining
 
@@ -1314,6 +1435,9 @@ class Result(LockAttributes):
 
 class SlothySelfCheckException(Exception):
     """Exception thrown upon selfcheck failures"""
+
+class SlothySelfTestException(Exception):
+    """Exception thrown upon selftest failures"""
 
 class SlothyBase(LockAttributes):
     """Stateless core of SLOTHY.
@@ -1874,6 +1998,8 @@ class SlothyBase(LockAttributes):
         self._extract_code()
         self._result.selfcheck_with_fixup(self.logger.getChild("selfcheck"))
         self._result.offset_fixup(self.logger.getChild("fixup"))
+
+        self._result.selftest(self.logger.getChild("selftest"))
 
     def _extract_positions(self, get_value):
 
@@ -2952,7 +3078,7 @@ class SlothyBase(LockAttributes):
             if isinstance(latency, int):
                 self.logger.debug("General latency constraint: [%s] >= [%s] + %d",
                     t, i.src, latency)
-                # Some microarchitectures have instructions with 0-cycle latency, i.e., the can 
+                # Some microarchitectures have instructions with 0-cycle latency, i.e., the can
                 # forward the result to an instruction in the same cycle (e.g., X+str on Cortex-M7)
                 # If that is the case we need to make sure that the consumer is after the producer
                 # in the output.

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -42,7 +42,8 @@ from slothy.core.config import Config
 from slothy.helper import LockAttributes, Permutation, DeferHandler, SourceLine, LLVM_Mc
 
 try:
-    from unicorn import Uc
+    from unicorn import *
+    from unicorn.arm_const import *
 except ImportError:
     Uc = None
 
@@ -877,11 +878,10 @@ class Result(LockAttributes):
             self._config.arch.RegisterType.list_registers(ty)]
 
         def run_code(code, txt=None):
-            objcode = LLVM_Mc.assemble(code, self._config.llvm_mc_binary,
+            objcode, offset = LLVM_Mc.assemble(code,
                                        self._config.arch.llvm_mc_arch,
                                        self._config.arch.llvm_mc_attr,
                                        log)
-
             # Setup emulator
             mu = Uc(self.config.arch.unicorn_arch, self.config.arch.unicorn_mode)
             # Copy initial register contents into emulator
@@ -897,7 +897,7 @@ class Result(LockAttributes):
             mu.mem_map(RAM_BASE, RAM_SZ)
             mu.mem_write(RAM_BASE, initial_memory)
             # Run emulator
-            mu.emu_start(CODE_BASE, CODE_BASE + len(objcode))
+            mu.emu_start(CODE_BASE + offset, CODE_BASE + len(objcode))
 
             final_register_contents = {}
             for r in regs:
@@ -937,7 +937,7 @@ class Result(LockAttributes):
                 if final_regs_old[r] != final_regs_new[r]:
                     raise SlothySelfTestException(f"Selftest failed: Register mismatch for {r}: {hex(final_regs_old[r])} != {hex(final_regs_new[r])}")
 
-        log.info("Selftest: OK")
+        log.info("Local selftest: OK")
 
     def selfcheck_with_fixup(self, log):
         """Do selfcheck, and consider preamble/postamble fixup in case of SW pipelining

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -32,7 +32,6 @@ from abc import ABC, abstractmethod
 from sympy import simplify
 from slothy.targets.common import *
 
-
 class SourceLine:
     """Representation of a single line of source code"""
 
@@ -1079,6 +1078,49 @@ class CPreprocessor():
 
         return [SourceLine(r) for r in unfolded_code]
 
+class LLVM_Mc_Error(Exception):
+    """Exception thrown if llvm-mc subprocess fails"""
+
+class LLVM_Mc():
+    """Helper class for the application of the LLVM MC tool"""
+
+    @staticmethod
+    def assemble(source, mc_binary, arch, attr, log):
+        """Runs LLVM-MC tool to assemble `source`, returning byte code"""
+
+        LLVM_MCA_BEGIN = SourceLine("").add_comment("LLVM-MCA-BEGIN")
+        LLVM_MCA_END = SourceLine("").add_comment("LLVM-MCA-END")
+
+        # Unfortunately, there is no option to directly extract byte code
+        # from LLVM-MC: One either gets a textual description, or an object file.
+        # To not introduce another binary dependency, we just extract the byte
+        # code directly from the textual output, which for every assembly line
+        # has a "encoding: [byte0, byte1, ...]" comment at the end.
+
+        code = SourceLine.write_multiline(source)
+        log.debug(f"Calling LLVM MC assmelber on the following code")
+        log.debug(code)
+        args = [f"--arch={arch}", "--assemble", "--show-encoding"]
+        if attr is not None:
+            args.append(f"--mattr={attr}")
+        try:
+            r = subprocess.run([mc_binary] + args,
+                               input=code, text=True, capture_output=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise LLVM_Mc_Error from exc
+
+        res = r.stdout.split('\n')
+        res = filter(lambda s: "encoding:" in s, res)
+        res = list(map(lambda s: s.split("encoding:")[1].strip(), res))
+
+        # Every line has the form "[byte, byte, byte,...]" now -- interpret as byte array
+        # Bit hacky, but nevermind...
+        def string_as_byte_array(s):
+            return s.replace("[", "").replace("]", "").split(",")
+        res = list(map(string_as_byte_array, res))
+        res = [int(b, base=16) for l in res for b in l] # Flatten
+        return bytes(res)
+
 class LLVM_Mca_Error(Exception):
     """Exception thrown if llvm-mca subprocess fails"""
 
@@ -1265,7 +1307,7 @@ class Loop(ABC):
                 elif loop_end_ctr > 0 and l_str != "":
                     # Case: The sequence of loop end candidates was interrupted
                     #       i.e., we found a false-positive or this is not a proper loop
-                    
+
                     # The loop end candidates are not part of the loop, meaning
                     # they belonged to the body
                     body += loop_end_candidates

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -81,6 +81,22 @@ class RegisterType(Enum):
     def spillable(reg_type):
         return reg_type in [RegisterType.GPR, RegisterType.NEON]
 
+    @staticmethod
+    def callee_saved_registers():
+        return [f"x{i}" for i in range(18,31)] + [f"v{i}" for i in range(8,16)]
+
+    @staticmethod
+    def unicorn_link_register():
+        return UC_ARM64_REG_X30
+
+    @staticmethod
+    def unicorn_stack_pointer():
+        return UC_ARM64_REG_SP
+
+    @staticmethod
+    def unicorn_program_counter():
+        return UC_ARM64_REG_PC
+
     @cache
     @staticmethod
     def unicorn_reg_by_name(reg):

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -40,17 +40,28 @@ similar to those used in the Arm ARM.
 import logging
 import inspect
 import re
+import os
 import math
+import platform
+import subprocess
 from enum import Enum
 from functools import cache
-
 from sympy import simplify
 
+from unicorn import *
+from unicorn.arm64_const import *
+
 from slothy.targets.common import *
-from slothy.helper import Loop
+from slothy.helper import Loop, LLVM_Mc
 
 arch_name = "Arm_AArch64"
+
 llvm_mca_arch = "aarch64"
+llvm_mc_arch = "aarch64"
+llvm_mc_attr = None
+
+unicorn_arch = UC_ARCH_ARM64
+unicorn_mode = UC_MODE_ARM
 
 class RegisterType(Enum):
     GPR = 1
@@ -69,6 +80,79 @@ class RegisterType(Enum):
     @staticmethod
     def spillable(reg_type):
         return reg_type in [RegisterType.GPR, RegisterType.NEON]
+
+    @cache
+    @staticmethod
+    def unicorn_reg_by_name(reg):
+        """Converts string name of register into numerical identifiers used
+        within the unicorn engine"""
+
+        d = {
+            "x0":  UC_ARM64_REG_X0,
+            "x1":  UC_ARM64_REG_X1,
+            "x2":  UC_ARM64_REG_X2,
+            "x3":  UC_ARM64_REG_X3,
+            "x4":  UC_ARM64_REG_X4,
+            "x5":  UC_ARM64_REG_X5,
+            "x6":  UC_ARM64_REG_X6,
+            "x7":  UC_ARM64_REG_X7,
+            "x8":  UC_ARM64_REG_X8,
+            "x9":  UC_ARM64_REG_X9,
+            "x10": UC_ARM64_REG_X10,
+            "x11": UC_ARM64_REG_X11,
+            "x12": UC_ARM64_REG_X12,
+            "x13": UC_ARM64_REG_X13,
+            "x14": UC_ARM64_REG_X14,
+            "x15": UC_ARM64_REG_X15,
+            "x16": UC_ARM64_REG_X16,
+            "x17": UC_ARM64_REG_X17,
+            "x18": UC_ARM64_REG_X18,
+            "x19": UC_ARM64_REG_X19,
+            "x20": UC_ARM64_REG_X20,
+            "x21": UC_ARM64_REG_X21,
+            "x22": UC_ARM64_REG_X22,
+            "x23": UC_ARM64_REG_X23,
+            "x24": UC_ARM64_REG_X24,
+            "x25": UC_ARM64_REG_X25,
+            "x26": UC_ARM64_REG_X26,
+            "x27": UC_ARM64_REG_X27,
+            "x28": UC_ARM64_REG_X28,
+            "x29": UC_ARM64_REG_X29,
+            "x30": UC_ARM64_REG_X30,
+            "v0":  UC_ARM64_REG_V0,
+            "v1":  UC_ARM64_REG_V1,
+            "v2":  UC_ARM64_REG_V2,
+            "v3":  UC_ARM64_REG_V3,
+            "v4":  UC_ARM64_REG_V4,
+            "v5":  UC_ARM64_REG_V5,
+            "v6":  UC_ARM64_REG_V6,
+            "v7":  UC_ARM64_REG_V7,
+            "v8":  UC_ARM64_REG_V8,
+            "v9":  UC_ARM64_REG_V9,
+            "v10": UC_ARM64_REG_V10,
+            "v11": UC_ARM64_REG_V11,
+            "v12": UC_ARM64_REG_V12,
+            "v13": UC_ARM64_REG_V13,
+            "v14": UC_ARM64_REG_V14,
+            "v15": UC_ARM64_REG_V15,
+            "v16": UC_ARM64_REG_V16,
+            "v17": UC_ARM64_REG_V17,
+            "v18": UC_ARM64_REG_V18,
+            "v19": UC_ARM64_REG_V19,
+            "v20": UC_ARM64_REG_V20,
+            "v21": UC_ARM64_REG_V21,
+            "v22": UC_ARM64_REG_V22,
+            "v23": UC_ARM64_REG_V23,
+            "v24": UC_ARM64_REG_V24,
+            "v25": UC_ARM64_REG_V25,
+            "v26": UC_ARM64_REG_V26,
+            "v27": UC_ARM64_REG_V27,
+            "v28": UC_ARM64_REG_V28,
+            "v29": UC_ARM64_REG_V29,
+            "v30": UC_ARM64_REG_V30,
+            "v31": UC_ARM64_REG_V31,
+        }
+        return d.get(reg, None)
 
     @cache
     @staticmethod

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -1,15 +1,23 @@
 import logging
 import inspect
+import os
 import re
 import math
 from enum import Enum
 from functools import cache
 
-from slothy.helper import SourceLine, Loop
+from unicorn import *
+from unicorn.arm_const import *
+
+from slothy.helper import SourceLine, Loop, LLVM_Mc
 from sympy import simplify
 
-llvm_mca_arch = "arm"  # TODO
+llvm_mca_arch = "arm"
+llvm_mc_arch = "arm"
+llvm_mc_attr = "armv5te"
 
+unicorn_arch = UC_ARCH_ARM
+unicorn_mode = UC_MODE_ARM
 
 class RegisterType(Enum):
     GPR = 1
@@ -26,6 +34,63 @@ class RegisterType(Enum):
     @staticmethod
     def spillable(reg_type):
         return reg_type in [RegisterType.GPR]
+
+    @cache
+    @staticmethod
+    def unicorn_reg_by_name(reg):
+        """Converts string name of register into numerical identifiers used
+        within the unicorn engine"""
+
+        d = {
+            "r0":  UC_ARM_REG_R0,
+            "r1":  UC_ARM_REG_R1,
+            "r2":  UC_ARM_REG_R2,
+            "r3":  UC_ARM_REG_R3,
+            "r4":  UC_ARM_REG_R4,
+            "r5":  UC_ARM_REG_R5,
+            "r6":  UC_ARM_REG_R6,
+            "r7":  UC_ARM_REG_R7,
+            "r8":  UC_ARM_REG_R8,
+            "r9":  UC_ARM_REG_R9,
+            "r10": UC_ARM_REG_R10,
+            "r11": UC_ARM_REG_R11,
+            "r12": UC_ARM_REG_R12,
+            "r13": UC_ARM_REG_SP,
+            "r14": UC_ARM_REG_LR,
+            "s0":  UC_ARM_REG_S0,
+            "s1":  UC_ARM_REG_S1,
+            "s2":  UC_ARM_REG_S2,
+            "s3":  UC_ARM_REG_S3,
+            "s4":  UC_ARM_REG_S4,
+            "s5":  UC_ARM_REG_S5,
+            "s6":  UC_ARM_REG_S6,
+            "s7":  UC_ARM_REG_S7,
+            "s8":  UC_ARM_REG_S8,
+            "s9":  UC_ARM_REG_S9,
+            "s10": UC_ARM_REG_S10,
+            "s11": UC_ARM_REG_S11,
+            "s12": UC_ARM_REG_S12,
+            "s13": UC_ARM_REG_S13,
+            "s14": UC_ARM_REG_S14,
+            "s15": UC_ARM_REG_S15,
+            "s16": UC_ARM_REG_S16,
+            "s17": UC_ARM_REG_S17,
+            "s18": UC_ARM_REG_S18,
+            "s19": UC_ARM_REG_S19,
+            "s20": UC_ARM_REG_S20,
+            "s21": UC_ARM_REG_S21,
+            "s22": UC_ARM_REG_S22,
+            "s23": UC_ARM_REG_S23,
+            "s24": UC_ARM_REG_S24,
+            "s25": UC_ARM_REG_S25,
+            "s26": UC_ARM_REG_S26,
+            "s27": UC_ARM_REG_S27,
+            "s28": UC_ARM_REG_S28,
+            "s29": UC_ARM_REG_S29,
+            "s30": UC_ARM_REG_S30,
+            "s31": UC_ARM_REG_S31,
+        }
+        return d.get(reg, None)
 
     @cache
     @staticmethod
@@ -125,12 +190,12 @@ class Branch:
 class VmovCmpLoop(Loop):
     """
     Loop ending in a vmov, a compare, and a branch.
-    
+
     The modification to the value we compare against happens inside the loop
     body. The value that is being compared to is stashed to a floating point
     register before the loop starts and therefore needs to be recovered before
-    the comparison. 
-    
+    the comparison.
+
     WARNING: This type of loop is experimental as slothy has no knowledge about
     what happens inside the loop boundary! Especially, a register is written
     inside the boundary which may be used for renaming by slothy. Use with
@@ -218,7 +283,7 @@ class CmpLoop(Loop):
     """
     Loop ending in a compare and a branch.
     The modification to the value we compare against happens inside the loop body.
-    WARNING: This type of loop is experimental as slothy has no knowledge about 
+    WARNING: This type of loop is experimental as slothy has no knowledge about
     what happens inside the loop boundary! Use with caution.
 
     Example:

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -13,8 +13,8 @@ from slothy.helper import SourceLine, Loop, LLVM_Mc
 from sympy import simplify
 
 llvm_mca_arch = "arm"
-llvm_mc_arch = "arm"
-llvm_mc_attr = "armv5te"
+llvm_mc_arch = "arm" ### TODO: What to put here?
+llvm_mc_attr = "armv5te,thumb2,dsp" ### TODO: What to put here?
 
 unicorn_arch = UC_ARCH_ARM
 unicorn_mode = UC_MODE_ARM
@@ -34,6 +34,22 @@ class RegisterType(Enum):
     @staticmethod
     def spillable(reg_type):
         return reg_type in [RegisterType.GPR]
+
+    @staticmethod
+    def callee_saved_registers():
+        return [f"r{i}" for i in range(4,12)] + [f"s{i}" for i in range(0,16)]
+
+    @staticmethod
+    def unicorn_link_register():
+        return UC_ARM_REG_LR
+
+    @staticmethod
+    def unicorn_program_counter():
+        return UC_ARM_REG_PC
+
+    @staticmethod
+    def unicorn_stack_pointer():
+        return UC_ARM_REG_SP
 
     @cache
     @staticmethod

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -46,6 +46,11 @@ from slothy.helper import Loop
 arch_name = "Arm_v81M"
 llvm_mca_arch = "arm"
 
+llvm_mc_arch = None
+llvm_mc_attr = None
+unicorn_arch = None
+unicorn_mode = None
+
 class RegisterType(Enum):
     GPR = 1,
     MVE = 2,
@@ -115,14 +120,14 @@ class RegisterType(Enum):
 class LeLoop(Loop):
     """
     Loop ending in a le instruction.
-    
+
     Example:
     ```
            loop_lbl:
                {code}
                le <cnt>, loop_lbl
     ```
-    
+
     where cnt is the loop counter in lr.
     """
     def __init__(self, lbl_start="1", lbl_end="2"):


### PR DESCRIPTION
By default, SLOTHY includes a 'selfcheck' verifying that the DFGs
of input and output are isomorphic with respect to the rescheduling
found by SLOTHY. This selfcheck is very powerful and should catch most
modelling errors in SLOTHY.

However, some aspects of SLOTHY remain outside of the scope of the
DFG-based selfcheck:

- Address offset fixup

  This is a historically rather error prone feature to which the self-check
  is blind (since it relies on making the DFG blind to address increments).

- Loop boundaries

  If SW pipelining is enabled, the selfcheck checks equivalence of a
  _bounded unrolling_ of the input and output loops.

  Therefore, it would not catch issues with (a) the loop boundary, or
  (b) exceptional iterations for low loop counts.

While it is not SLOTHY's goal to provide formal guarantees of correctness
of the optimizations -- this should be gauged/confirmed through extensive test
and ideally formal verification -- development would be faster if bugs
in the aforementioned areas were caught before the developer integrates
and tests the SLOTHY output manually.

As a step towards catching more potential pitfalls early in the SLOTHY
workflow, this commit starts the development of an _equivalence tester_.

The idea of the equivalence tester is simple: Just run original and optimized
assembly with various random inputs, and check that they indeed lead to
equivalent outputs.

This commit implements this idea for AArch64 and Armv7-M, leveraging
LLVM-MC as an assembler and the unicorn-engine for emulation.

An initial limitation is support for loops: For now, the equivalence
checker tests bounded unrollings of loops, just like the selfcheck. That is
against the point of the equivalenc check, but it will be improved at a later
point, after some refactoring of the loop generation code.

The checker added in this commit is able to detect issues with address offset
fixup, however, which would previously have gone unnoticed by the selfcheck.

The new equivalence test is configured via config.selftest, which is enabled
by default, but silently skipped for unsupported platforms or target architectures.
