### PR TITLE
Extend Armv7E-M architecture model

### DIFF
--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -650,7 +650,7 @@ class Armv7mInstruction(Instruction):
         imm_pattern = "#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|,)+"
         index_pattern = "[0-9]+"
         width_pattern = "(?:\.w|\.n|)"
-        barrel_pattern = "(?:lsl|ror|lsr|asr)"
+        barrel_pattern = "(?:lsl|ror|lsr|asr)\\\\s*"
         range_pattern = "\{(?P<range_type>[rs])(?P<range_start>\\\\d+)-[rs](?P<range_end>\\\\d+)\}"
 
         src = re.sub(" ", "\\\\s+", src)
@@ -968,7 +968,7 @@ class add_imm_short(Armv7mBasicArithmetic): # pylint: disable=missing-docstring,
     in_outs = ["Rd"]
 
 class add_shifted(Armv7mShiftedArithmetic): # pylint: disable=missing-docstring,invalid-name
-    pattern = "add<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "add<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra","Rb"]
     outputs = ["Rd"]
 
@@ -995,7 +995,7 @@ class sub(Armv7mBasicArithmetic): # pylint: disable=missing-docstring,invalid-na
     outputs = ["Rd"]
 
 class sub_shifted(Armv7mShiftedArithmetic): # pylint: disable=missing-docstring,invalid-name
-    pattern = "sub<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "sub<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra","Rb"]
     outputs = ["Rd"]
 
@@ -1138,7 +1138,7 @@ class log_and(Armv7mLogical): # pylint: disable=missing-docstring,invalid-name
     outputs = ["Rd"]
 
 class log_and_shifted(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "and<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "and<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 
@@ -1148,7 +1148,7 @@ class log_or(Armv7mLogical): # pylint: disable=missing-docstring,invalid-name
     outputs = ["Rd"]
 
 class log_or_shifted(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "orr<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "orr<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 
@@ -1175,7 +1175,7 @@ class eors_short(Armv7mLogical): # pylint: disable=missing-docstring,invalid-nam
     modifiesFlags = True
 
 class eor_shifted(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "eor<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "eor<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 
@@ -1195,7 +1195,7 @@ class bics(Armv7mLogical): # pylint: disable=missing-docstring,invalid-name
     modifiesFlags = True
 
 class bic_shifted(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "bic<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "bic<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 
@@ -1235,7 +1235,7 @@ class asrs(Armv7mLogical): # pylint: disable=missing-docstring,invalid-name
     modifiesFlags = True
 
 class pkhtb(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "pkhtb<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "pkhtb<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 
@@ -1245,7 +1245,7 @@ class pkhbt(Armv7mLogical): # pylint: disable=missing-docstring,invalid-name
     outputs = ["Rd"]
 
 class pkhbt_shifted(Armv7mShiftedLogical): # pylint: disable=missing-docstring,invalid-name
-    pattern = "pkhbt<width> <Rd>, <Ra>, <Rb>, <barrel> <imm>"
+    pattern = "pkhbt<width> <Rd>, <Ra>, <Rb>, <barrel><imm>"
     inputs = ["Ra", "Rb"]
     outputs = ["Rd"]
 

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -483,6 +483,7 @@ class Instruction:
                                       ldr_with_imm_stack,
                                       ldr_with_postinc,
                                       ldrh_with_postinc,
+                                      ldrb_with_postinc,
                                       ldrd_imm,
                                       ldrd_with_postinc,
                                       ldr_with_inc_writeback,
@@ -1083,6 +1084,12 @@ class smlatt(Armv7mMultiplication): # pylint: disable=missing-docstring,invalid-
     inputs = ["Ra","Rb", "Rc"]
     outputs = ["Rd"]
 
+class smlatb(Armv7mMultiplication): # pylint: disable=missing-docstring,invalid-name
+    pattern = "smlatb<width> <Rd>, <Ra>, <Rb>, <Rc>"
+    inputs = ["Ra","Rb", "Rc"]
+    outputs = ["Rd"]
+
+
 class smull(Armv7mMultiplication): # pylint: disable=missing-docstring,invalid-name
     pattern = "smull<width> <Ra>, <Rb>, <Rc>, <Rd>"
     inputs = ["Rc","Rd"]
@@ -1354,6 +1361,21 @@ class ldrh_with_postinc(Armv7mLoadInstruction): # pylint: disable=missing-docstr
         obj.pre_index = None
         obj.addr = obj.args_in_out[0]
         return obj
+
+
+class ldrb_with_postinc(Armv7mLoadInstruction): # pylint: disable=missing-docstring,invalid-name
+    pattern = "ldrb<width> <Rd>, [<Ra>], <imm>"
+    in_outs = [ "Ra" ]
+    outputs = ["Rd"]
+    @classmethod
+    def make(cls, src):
+        obj = Armv7mLoadInstruction.build(cls, src)
+        obj.increment = obj.immediate
+        obj.args_inout_out_different = [(0,0)] # Can't have Rd==Ra
+        obj.pre_index = None
+        obj.addr = obj.args_in_out[0]
+        return obj
+
 
 class Ldrd(Armv7mLoadInstruction):
     pass

--- a/slothy/targets/arm_v7m/cortex_m7.py
+++ b/slothy/targets/arm_v7m/cortex_m7.py
@@ -118,6 +118,7 @@ execution_units = {
         ldrb_with_imm,
         ldrh_with_imm,
         ldrh_with_postinc,
+        ldrb_with_postinc,
         vldr_with_imm, vldr_with_postinc  # TODO: also FPU?
         ): ExecutionUnit.LOAD(),
     (
@@ -152,7 +153,7 @@ execution_units = {
     ): ExecutionUnit.ALU(),
     (ror, ror_short, rors_short, lsl, asr, asrs): [[ExecutionUnit.ALU0], [ExecutionUnit.ALU1]],
     (mul, mul_short, smull, smlal, mla, mls, smulwb, smulwt, smultb, smultt,
-     smulbb, smlabt, smlabb, smlatt, smlad, smladx, smuad, smuadx, smmulr): [ExecutionUnit.MAC],
+     smulbb, smlabt, smlabb, smlatt, smlatb, smlad, smladx, smuad, smuadx, smmulr): [ExecutionUnit.MAC],
     (vmov_gpr, vmov_gpr2, vmov_gpr2_dual): [ExecutionUnit.FPU],
     (uadd16, sadd16, usub16, ssub16): list(map(list, product(ExecutionUnit.ALU(), [ExecutionUnit.SIMD]))),
     (pkhbt, pkhtb, pkhbt_shifted, ubfx_imm): [[ExecutionUnit.ALU0, ExecutionUnit.SIMD]],
@@ -170,6 +171,7 @@ inverse_throughput = {
         ldrb_with_imm,
         ldrh_with_imm,
         ldrh_with_postinc,
+        ldrb_with_postinc,
         vldr_with_imm, vldr_with_postinc,  # TODO: double-check
         # actually not, just placeholder
         ldm_interval, ldm_interval_inc_writeback, vldm_interval_inc_writeback,
@@ -188,7 +190,7 @@ inverse_throughput = {
         mul, mul_short,
         smull,
         smlal,
-        mla, mls, smulwb, smulwt, smultb, smultt, smulbb, smlabt, smlabb, smlatt, smlad, smladx, smuad, smuadx, smmulr,
+        mla, mls, smulwb, smulwt, smultb, smultt, smulbb, smlabt, smlabb, smlatt, smlatb, smlad, smladx, smuad, smuadx, smmulr,
         neg_short,
         log_and, log_and_shifted,
         log_or, log_or_shifted,
@@ -251,7 +253,7 @@ default_latencies = {
         mul, mul_short,
         smull,
         smlal,
-        mla, mls, smulwb, smulwt, smultb, smultt, smulbb, smlabt, smlabb, smlatt, smlad, smladx, smuad, smuadx, smmulr,
+        mla, mls, smulwb, smulwt, smultb, smultt, smulbb, smlabt, smlabb, smlatt, smlatb, smlad, smladx, smuad, smuadx, smmulr,
         # TODO: Verify load latency
         stm_interval_inc_writeback,  # actually not, just placeholder
         ldr,
@@ -262,6 +264,8 @@ default_latencies = {
         ldrb_with_imm,
         ldrh_with_imm,
         ldrh_with_postinc,
+        ldrb_with_postinc,
+        ldrb_with_postinc,
         eor_shifted
     ): 2,
     (Ldrd): 3,
@@ -279,7 +283,7 @@ def get_latency(src, out_idx, dst):
     latency = lookup_multidict(default_latencies, src)
 
     # Forwarding path to MAC instructions
-    if instclass_dst in [mla, mls, smlabb, smlabt, smlatt] and src.args_out[0] == dst.args_in[2]:
+    if instclass_dst in [mla, mls, smlabb, smlabt, smlatt, smlatb] and src.args_out[0] == dst.args_in[2]:
         latency =  latency - 1
 
     if instclass_dst in [smlal] and \


### PR DESCRIPTION
Small tweaks to the Armv7E-M model: 
- Add `smlatb` and `ldrb` with postincrement (and corresponding uArch model for M7)
- make barrel shift parsing more flexibile (can now write either `asr#1` or `asr #1` (before it was limited to the latter)