### PR TITLE
fix Python3.12 reg ex warnings

### DIFF
--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -775,7 +775,7 @@ class AsmMacro():
             return a
 
         def apply_arg(l, arg, val):
-            l = re.sub(f"\\\\{arg}\\\\\(\)", val, l)
+            l = re.sub(f"\\\\{arg}\\\\\\(\\)", val, l)
             l = re.sub(f"\\\\{arg}(\\W|$)",val + "\\1", l)
             l = l.replace("\\()\\()", "\\()")
             return l
@@ -816,7 +816,7 @@ class AsmMacro():
         for arg in self.args:
             arg_regexps.append(rf"\s*(?P<{arg}>[^,]+)\s*")
 
-        macro_regexp_txt += '(,|\s)'.join(arg_regexps)
+        macro_regexp_txt += '(,|\\s)'.join(arg_regexps)
         macro_regexp = re.compile(macro_regexp_txt)
 
         output = []


### PR DESCRIPTION
I'm getting the following warnings with Python3.12: 
```
/home/mjk/git/slothy/slothy/helper.py:778: SyntaxWarning: invalid escape sequence '\('
  l = re.sub(f"\\\\{arg}\\\\\(\)", val, l)
/home/mjk/git/slothy/slothy/helper.py:819: SyntaxWarning: invalid escape sequence '\s'
  macro_regexp_txt += '(,|\s)'.join(arg_regexps)
```

This commit fixes the escaping.