### PR TITLE
Refine selftest further

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -135,15 +135,15 @@ class Config(NestedPrint, LockAttributes):
         return self._selftest_iterations
 
     @property
-    def selftest_address_gprs(self):
+    def selftest_address_registers(self):
         """Dictionary of (reg, sz) items indicating which registers are assumed to be
         pointers to memory, and if so, of what size."""
-        return self._selftest_address_gprs
+        return self._selftest_address_registers
 
     @property
     def selftest_default_memory_size(self):
         """Default buffer size to use for registers which are automatically inferred to be
-        used as pointers and for which no memory size has been configured via `address_gprs`."""
+        used as pointers and for which no memory size has been configured via `address_registers`."""
         return self._selftest_default_memory_size
 
     @property
@@ -1183,7 +1183,7 @@ class Config(NestedPrint, LockAttributes):
 
         self._selftest = True
         self._selftest_iterations = 10
-        self._selftest_address_gprs = None
+        self._selftest_address_registers = None
         self._selftest_default_memory_size = 1024
         self._selfcheck = True
         self._selfcheck_failure_logfile = None
@@ -1307,9 +1307,9 @@ class Config(NestedPrint, LockAttributes):
     @selftest_iterations.setter
     def selftest_iterations(self,val):
         self._selftest_iterations = val
-    @selftest_address_gprs.setter
-    def selftest_address_gprs(self,val):
-        self._selftest_address_gprs = val
+    @selftest_address_registers.setter
+    def selftest_address_registers(self,val):
+        self._selftest_address_registers = val
     @selftest_default_memory_size.setter
     def selftest_default_memory_size(self,val):
         self._selftest_default_memory_size = val

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -870,6 +870,21 @@ class Result(LockAttributes):
         iterations = 7
         if self.config.sw_pipelining.enabled is True:
             old_source, new_source = self.get_fully_unrolled_loop(iterations)
+
+            dfgc_preamble = DFGConfig(self.config, outputs=self.kernel_input_output)
+            dfgc_preamble.inputs_are_outputs = False
+            preamble_dfg = DFG(self.preamble, log, dfgc_preamble)
+
+            if preamble_dfg.has_symbolic_registers():
+                log.info("Skipping selftest as preamble contains symbolic registers.")
+                return
+
+            dfgc_postamble = DFGConfig(self.config, outputs=self.orig_outputs)
+            postamble_dfg = DFG(self.postamble, log.getChild("new_postamble"), dfgc_postamble)
+
+            if postamble_dfg.has_symbolic_registers():
+                log.info("Skipping selftest as postamble contains symbolic registers.")
+                return
         else:
             old_source, new_source = self.orig_code, self.code
 

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -846,8 +846,8 @@ class Result(LockAttributes):
 
         log.info(f"Running selftest ({self._config.selftest_iterations} iterations)...")
 
-        address_gprs = self._config.selftest_address_gprs
-        if address_gprs is None:
+        address_registers = self._config.selftest_address_registers
+        if address_registers is None:
             # Try to infer which registes need to be pointers
             # Look for load/store instructions and remember addresses
             addresses = set()
@@ -862,8 +862,8 @@ class Result(LockAttributes):
             # just allocate a buffer of a configurable default size.
             log.info(f"Inferred that the following registers seem to act as pointers: {addresses}")
             log.info(f"Using default buffer size of {self._config.selftest_default_memory_size} bytes. "
-                     "If you want different buffer sizes, set selftest_address_gprs manually.")
-            address_gprs = { a: self._config.selftest_default_memory_size for a in addresses }
+                     "If you want different buffer sizes, set selftest_address_registers manually.")
+            address_registers = { a: self._config.selftest_default_memory_size for a in addresses }
 
         # This produces _unrolled_ code, the same that is checked in the selfcheck.
         # The selftest should instead use the rolled form of the loop.
@@ -879,7 +879,7 @@ class Result(LockAttributes):
         regs_expected = set(filter(lambda t: t.startswith("t") is False and
                                          t != "sp" and t != "flags", regs_expected))
 
-        SelfTest.run(self.config, log, old_source, new_source, address_gprs, regs_expected,
+        SelfTest.run(self.config, log, old_source, new_source, address_registers, regs_expected,
                      self.config.selftest_iterations)
 
     def selfcheck_with_fixup(self, log):

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -855,7 +855,7 @@ class Result(LockAttributes):
                 addr = getattr(t.inst, "addr", None)
                 if addr is None:
                     continue
-                addresses.add(addr)
+                addresses = addresses.union(tree.find_all_predecessors_input_registers(t, addr))
 
             # For now, we don't look into increments and immedate offsets
             # to gauge the amount of memory we actually need. Instaed, we

--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -172,7 +172,7 @@ class Slothy:
         for l in s:
             fun(f"> {l}")
 
-    def global_selftest(self, funcname, address_gprs, iterations=5):
+    def global_selftest(self, funcname, address_registers, iterations=5):
         """Conduct a function-level selftest
 
         - funcname: Name of function to be called. Must be exposed as a symbol
@@ -198,7 +198,7 @@ class Slothy:
         old_source = self.original_source
         new_source = self.source
 
-        SelfTest.run(self.config, log, old_source, new_source, address_gprs,
+        SelfTest.run(self.config, log, old_source, new_source, address_registers,
                      self.config.arch.RegisterType.callee_saved_registers(), 5,
                      fnsym=funcname)
 

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -1338,6 +1338,7 @@ class SelfTest():
                 log.error("Failed to emulate code using unicorn engine")
                 log.error("Code")
                 log.error(SourceLine.write_multiline(code))
+                raise SelfTestException("Selftest failed: Unicorn failed to emulate code")
 
             final_register_contents = {}
             for r in regs:

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -1282,7 +1282,7 @@ class SelfTestException(Exception):
 class SelfTest():
 
     @staticmethod
-    def run(config, log, codeA, codeB, address_gprs, output_registers, iterations, fnsym=None):
+    def run(config, log, codeA, codeB, address_registers, output_registers, iterations, fnsym=None):
         CODE_BASE = 0x010000
         CODE_SZ = 0x010000
         CODE_END = CODE_BASE + CODE_SZ
@@ -1359,7 +1359,7 @@ class SelfTest():
             initial_register_contents = {}
             for r in regs:
                 initial_register_contents[r] = int.from_bytes(os.urandom(16))
-            for (reg, sz) in address_gprs.items():
+            for (reg, sz) in address_registers.items():
                 initial_register_contents[reg] = cur_ram
                 cur_ram += sz
 

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -1314,8 +1314,8 @@ class SelfTest():
                 # If we expect a function return, put a valid address in the LR
                 # that serves as the marker to terminate emulation
                 mu.reg_write(config.arch.RegisterType.unicorn_link_register(), CODE_END)
-            # Setup stack
-            mu.reg_write(config.arch.RegisterType.unicorn_stack_pointer(), STACK_TOP)
+            # Setup stack and allocate initial stack memory
+            mu.reg_write(config.arch.RegisterType.unicorn_stack_pointer(), STACK_TOP - config.selftest_default_memory_size)
             # Copy code into emulator
             mu.mem_map(CODE_BASE, CODE_SZ)
             mu.mem_write(CODE_BASE, objcode)

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -1334,11 +1334,11 @@ class SelfTest():
                     mu.emu_start(CODE_BASE + offset, CODE_BASE + len(objcode))
                 else:
                     mu.emu_start(CODE_BASE + offset, CODE_END)
-            except:
+            except UcError as e:
                 log.error("Failed to emulate code using unicorn engine")
                 log.error("Code")
                 log.error(SourceLine.write_multiline(code))
-                raise SelfTestException("Selftest failed: Unicorn failed to emulate code")
+                raise SelfTestException(f"Selftest failed: Unicorn failed to emulate code: {str(e)}") from e
 
             final_register_contents = {}
             for r in regs:

--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -1360,8 +1360,10 @@ class SelfTest():
             for r in regs:
                 initial_register_contents[r] = int.from_bytes(os.urandom(16))
             for (reg, sz) in address_registers.items():
-                initial_register_contents[reg] = cur_ram
-                cur_ram += sz
+                # allocate 2*sz and place pointer in the middle
+                # this makes sure that memory can be accessed at negative offsets
+                initial_register_contents[reg] = cur_ram + sz
+                cur_ram += 2*sz
 
             final_regs_old, final_mem_old = run_code(codeA, txt="old")
             final_regs_new, final_mem_new = run_code(codeB, txt="new")


### PR DESCRIPTION
We encountered further issues with the selftest in the `armv7m` branch. This PR refines it further

1) When unicorn fails to run code, currently this fails silently and the selftest continues to run failing in the assertions checking the output resulting in misleading error messages. This is changed now to fail immediately with an appropriate eror message. 

2) The configuration option `selftest_address_gprs` was misnamed as addresses can also be contained in non-gpr-registers. I renamed it to `selftest_address_registers`

3) Previously the selftest would determine which registers are supposed to contain addresses  (and allocate memory
accordingly) by going through all memory operations and assuming that address registers used in those are the
inputs holding the addresses initially.

This assumption does not hold as
(1) addresses may be moved around
(2) addresses may actually be a result of a previous computation.

One example where this did not work was
```
vmov rX, sY
ldr rZ, [rX]
```

Here the selftest would assume that rX needs to be an address. However, sY is the register holding the address on entry of the code.

This commit refines the code determining the address registers by recursively going through the DFG and determining the _input_ registers that affect values being used as addresses.
Note that in the above examples rX would not be marked as an address, at it is not an input.

Hopefully this approach is more robust.


4) Allow accessing memory at negative offsets. Sometimes code has pointers that do not point at the start of the buffer, but somewhere in the middle. If those are then used with negative offsets, unicorn fails as the memory is potentially undefined. This is fixed by allocating a double-sized buffer and placing the pointer in the middle. 

5) The stack pointer is currently initialized to the top of the stack. However, if code is using the stack pointer (and the sp is not decremented as a part of the code snipped), then we get memory access errors from unicorn. This is fixed by allocating some stack space (the default buffer size) before calling the function. 

6) Building on top of #122, we also need to skip the selftest if symbolics are present in the preamble or postamble in the case of sw piplining. This PR adds the check in the same way as #122 did for the main body of the code.
