### PR TITLE
Fix counter correction for SW pipelining with early + late insts

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -303,7 +303,8 @@ class SubsLoop(Loop):
         if fixup != 0:
             # In case the immediate is >1, we need to scale the fixup. This
             # allows for loops that do not use an increment of 1
-            fixup *= self.additional_data['imm']
+            assert isinstance(fixup, int)
+            fixup = simplify(f"{fixup} * ({self.additional_data['imm']})")
             yield f"{indent}sub {loop_cnt}, {loop_cnt}, #{fixup}"
         if jump_if_empty is not None:
             yield f"cbz {loop_cnt}, {jump_if_empty}"


### PR DESCRIPTION
When both early and late instructions are used, the loop counter needs adjusting by 2. A recent change broke this because of an unfortunate type confusion leading to the computation of `2 * '1' == '11'` rather than `2 * 1 == 2`.

This commit fixes the computation of the loop counter adjustment.