### PR TITLE
Fix typo in pretty-printing of orig<->opt permutation

### DIFF
--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -652,7 +652,7 @@ class Result(LockAttributes):
                     yield from gen_restore(reg, loc, gen_vis(0, d))
                 for (reg, loc) in spills:
                     yield from gen_spill(reg, loc, gen_vis(0, d))
-                if p is None and len(s) == 0 and len(r) == 0:
+                if p is None and len(spills) == 0 and len(restores) == 0:
                     gap_str = "gap"
                     yield SourceLine("")    \
                         .set_comment(f"{gap_str:{fixlen-4}s}") \


### PR DESCRIPTION
Noticed this was still broken on `main` while re-optimizing 769 Dilithium NTT. 