### PR TITLE
Fix aarch64 loop labels being overwritten

### DIFF
--- a/examples/opt/aarch64/aarch64_loop_subs_opt_a55.s
+++ b/examples/opt/aarch64/aarch64_loop_subs_opt_a55.s
@@ -1,0 +1,26 @@
+count .req x2
+
+mov count, #16
+start:
+                   // Instructions:    1
+                   // Expected cycles: 1
+                   // Expected IPC:    1.00
+                   //
+                   // Cycle bound:     1.0
+                   // IPC bound:       1.00
+                   //
+                   // Wall time:     0.01s
+                   // User time:     0.01s
+                   //
+                   // ----- cycle (expected) ------>
+                   // 0                        25
+                   // |------------------------|----
+        nop        // *.............................
+
+                    // ------ cycle (expected) ------>
+                    // 0                        25
+                    // |------------------------|-----
+        // nop      // *..............................
+
+        sub count, count, 1
+        cbnz count, start

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -286,8 +286,8 @@ class SubsLoop(Loop):
     ```
     where cnt is the loop counter in lr.
     """
-    def __init__(self, lbl="lbl", lbl_start="1", lbl_end="2", loop_init="lr") -> None:
-        super().__init__(lbl_start=lbl_start, lbl_end=lbl_end, loop_init=loop_init)
+    def __init__(self, lbl="lbl") -> None:
+        super().__init__()
         # The group naming in the regex should be consistent; give same group
         # names to the same registers
         self.lbl = lbl

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -290,6 +290,7 @@ class SubsLoop(Loop):
         super().__init__(lbl_start=lbl_start, lbl_end=lbl_end, loop_init=loop_init)
         # The group naming in the regex should be consistent; give same group
         # names to the same registers
+        self.lbl = lbl
         self.lbl_regex = r"^\s*(?P<label>\w+)\s*:(?P<remainder>.*)$"
         self.end_regex = (r"^\s*sub[s]?\s+(?P<cnt>\w+),\s*(?P<reg1>\w+),\s*#(?P<imm>\d+)",
                                rf"^\s*(cbnz|bnz|bne)\s+(?P<cnt>\w+),\s*{lbl}")
@@ -308,12 +309,12 @@ class SubsLoop(Loop):
             yield f"{indent}sub {loop_cnt}, {loop_cnt}, #{fixup}"
         if jump_if_empty is not None:
             yield f"cbz {loop_cnt}, {jump_if_empty}"
-        yield f"{self.lbl_start}:"
+        yield f"{self.lbl}:"
 
     def end(self, other, indentation=0):
         """Emit compare-and-branch at the end of the loop"""
         indent = ' ' * indentation
-        lbl_start = self.lbl_start
+        lbl_start = self.lbl
         if lbl_start.isdigit():
             lbl_start += "b"
 


### PR DESCRIPTION
This PR addresses the issue #165. In the `SubsLoop` class, the wrong parameter was used in the writer of loop. 

The parameters `lbl_start`, `lbl_end` are some legacy carry-over from the Armv8-M models. I feel like we could remove them globally at some point as they do not add too much value in my opinion. 

* Resolves #165