### PR TITLE
Update README for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ SLOTHY has been successfully used on
 - Ubuntu-21.10 and up (64-bit),
 - macOS Monterey 12.6 and up.
 
-SLOTHY requires Python 3.11. See [requirements.txt](requirements.txt) for package requirements, and install via `pip
-install -r requirements.txt`.
+SLOTHY requires Python 3.11 (consider using pyenv to pin your Python version locally).
+See [requirements.txt](requirements.txt) for package requirements, and install via `pip install -r requirements.txt`.
 
 **Note:** `requirements.txt` pins versions for reproducibility. If you already have newer versions of some dependencies
 installed and don't want them downgraded, consider using a virtual environment:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SLOTHY has been successfully used on
 - Ubuntu-21.10 and up (64-bit),
 - macOS Monterey 12.6 and up.
 
-SLOTHY requires Python >= 3.10. See [requirements.txt](requirements.txt) for package requirements, and install via `pip
+SLOTHY requires Python 3.11. See [requirements.txt](requirements.txt) for package requirements, and install via `pip
 install -r requirements.txt`.
 
 **Note:** `requirements.txt` pins versions for reproducibility. If you already have newer versions of some dependencies
@@ -85,6 +85,8 @@ python3 -m venv venv
 ```
 
 Then, enter the virtual environment via `source venv/bin/activate` prior to running SLOTHY.
+Finally, adjust your PATH environment variable to include the directories containining
+the `slothy-cli` script and the LLVM `llvm-mca` tool.
 
 ### Docker
 


### PR DESCRIPTION
Fixes #173 

Document that Python 3.11 is required now.
Document need to adjust PATH to include slothy-cli and LLVM tools.
