### PR TITLE
Update pydoclint to 0.6.5 and resolve warnings 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ myst_parser
 sphinx-autobuild
 sphinx-autodoc2
 flake8==7.2.0
-pydoclint==0.6.2
+pydoclint==0.6.5
 black

--- a/slothy/core/dataflow.py
+++ b/slothy/core/dataflow.py
@@ -196,7 +196,6 @@ class ComputationNode:
     :param src_in_out: A list of RegisterSource instances representing the inputs to the
         instruction which are also written to.
     :type src_in_out: list
-    :raises AssertionError: If input arguments are invalid.
 
     """
 

--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -352,8 +352,6 @@ class Heuristics:
             the preamble and postamble (the caller will need this to adjust the
             loop counter).
         :rtype: any
-        :raises AssertionError: If kernel is not a list of SourceLine.
-
         """
 
         if conf.sw_pipelining.enabled and not conf.inputs_are_outputs:
@@ -447,7 +445,6 @@ class Heuristics:
         :return: A Result object representing the final optimization result.
         :rtype: any
         :raises SlothyException: If software pipelining is enabled.
-        :raises AssertionError: If body is not a list of SourceLine.
         """
         assert SourceLine.is_source(body)
         if conf.sw_pipelining.enabled:

--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -338,9 +338,6 @@ class Slothy:
         :type loop_synthesis_cb: any
         :param logname: Optional name of the logger.
         :type logname: str
-        :raises AssertionError: If sw pipelining is disabled and yet there are
-              early/late instructions (which should not happen) or if the optimized code
-              is not a SourceLine list.
         """
         if logname is None and start is not None:
             logname = start
@@ -509,8 +506,6 @@ class Slothy:
         :type end: str
         :param **kwargs: Additional arguments to pass to the fusion callbacks.
         :type **kwargs: any
-        :raises AssertionError: If self.source is not a SourceLine list when
-              returning.
         """
         logger = self.logger.getChild(f"ssa_{start}_{end}")
         pre, body, post = AsmHelper.extract(self.source, start, end)
@@ -534,8 +529,6 @@ class Slothy:
         :type forced_loop_type: any
         :param **kwargs: Additional arguments to pass to the fusion callbacks.
         :type **kwargs: any
-        :raises AssertionError: If self.source is not a SourceLine list when
-              returning.
         """
         logger = self.logger.getChild(f"ssa_loop_{loop_lbl}")
 


### PR DESCRIPTION
Resolves #186 
Depends on #185.

According to https://github.com/jsh9/pydoclint/issues/213 it was a bug that pydoclint expected AssertionErrors to be listed in the raises section of the docstrings. 
With pydoclint 0.6.5 that was reverted and you _cannot_ have AssertionErrors in the docstrings. Unfortunately that means that linting will fail iwht pydoclint >= 0.6.1 and < 0.6.5....