### PR TITLE
Only reference API-relevant args in `vldr_gather.write()`

### DIFF
--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -1749,7 +1749,7 @@ class vldr_gather(Instruction):
         uxtw = ""
         if self.uxtw is not None:
             uxtw = f", UXTW #{self.uxtw}"
-        addr = f"[{self.addrgpr}, {self.addrvec}{uxtw}]"
+        addr = f"[{self.args_in[0]}, {self.args_in[1]}{uxtw}]"
 
         return f"vldr{self.width}.{self.datatype} {self.args_out[0]}, {addr}"
 


### PR DESCRIPTION
This change fixes a bug with `vldr_gather` where registers are not renamed correctly. The bug is caused by `vldr_gather.write()` tracking old data from parse-time, rather than updated registers from renaming.

Fixes #202