### PR TITLE
AArch64: Don't enforce whitespacing before/after separating tokens

### DIFF
--- a/examples/naive/aarch64/aarch64_simple0.s
+++ b/examples/naive/aarch64/aarch64_simple0.s
@@ -1,15 +1,15 @@
 ldr q0, [x1, #0]
 ldr q1, [x2, #0]
 
-ldr q8,  [x0]
-ldr q9,  [x0, #1*16]
-ldr q10, [x0, #2*16]
-ldr q11, [x0, #3*16]
+ldr q8,[x0]
+ldr q9, [x0, #1*16]
+ldr q10,[x0, #2*16]
+ldr q11,[x0,#3*16]
 
 mul v24.8h, v9.8h, v0.h[0]
 sqrdmulh v9.8h, v9.8h, v0.h[1]
 mls v24.8h, v9.8h, v1.h[0]
-sub     v9.8h,    v8.8h, v24.8h
+sub v9.8h,v8.8h,v24.8h
 add     v8.8h,    v8.8h, v24.8h
 
 mul v24.8h, v11.8h, v0.h[0]


### PR DESCRIPTION
* Resolves #201 

Previously, a whitespace before/after a separating token such as ',' inside an instruction pattern would be interpreted as mandatory, leading to parsing failures for valid instructions strings such as 'ldr q0,[x0]'.

This commit fixes this by allowing any amount of whitespaces before/after tokens such as ',', '.', '[', ']', regardless of the number of spaces in the instruction pattern.