### PR TITLE
AArch64: Relax spacing around immediates, add some shifted logical instructions

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -808,6 +808,7 @@ class AArch64Instruction(Instruction):
         # pattern by regular expressions allowing flexible whitespacing.
         flexible_spacing = [
             (r"\s*,\s*", r"\\s*,\\s*"),
+            (r"\s*<imm>\s*", r"\\s*<imm>\\s*"),
             (r"\s*\[\s*", r"\\s*\\[\\s*"),
             (r"\s*\]\s*", r"\\s*\\]\\s*"),
             (r"\s*\.\s*", r"\\s*\\.\\s*"),

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -2538,20 +2538,24 @@ class orr_shifted(AArch64LogicalShifted):
     inputs = ["Xa", "Xb"]
     outputs = ["Xd"]
 
+
 class orr_shifted_asr_w(AArch64LogicalShifted):
     pattern = "and <Wd>, <Wa>, <Wb>, asr <imm>"
     inputs = ["Wa", "Wb"]
     outputs = ["Wd"]
+
 
 class orr_shifted_asr(AArch64LogicalShifted):
     pattern = "orr <Xd>, <Xa>, <Xb>, asr <imm>"
     inputs = ["Xa", "Xb"]
     outputs = ["Xd"]
 
+
 class eor_shifted_lsl(AArch64LogicalShifted):
     pattern = "eor <Xd>, <Xa>, <Xb>, lsl <imm>"
     inputs = ["Xa", "Xb"]
     outputs = ["Xd"]
+
 
 class AArch64ConditionalCompare(AArch64Instruction):
     pass

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -2538,6 +2538,20 @@ class orr_shifted(AArch64LogicalShifted):
     inputs = ["Xa", "Xb"]
     outputs = ["Xd"]
 
+class orr_shifted_asr_w(AArch64LogicalShifted):
+    pattern = "and <Wd>, <Wa>, <Wb>, asr <imm>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+class orr_shifted_asr(AArch64LogicalShifted):
+    pattern = "orr <Xd>, <Xa>, <Xb>, asr <imm>"
+    inputs = ["Xa", "Xb"]
+    outputs = ["Xd"]
+
+class eor_shifted_lsl(AArch64LogicalShifted):
+    pattern = "eor <Xd>, <Xa>, <Xb>, lsl <imm>"
+    inputs = ["Xa", "Xb"]
+    outputs = ["Xd"]
 
 class AArch64ConditionalCompare(AArch64Instruction):
     pass


### PR DESCRIPTION
* Based on #212 

Found during some joint debugging with @nebeid