### PR TITLE
feat: Add ifelse test for armv8m

### DIFF
--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -130,6 +130,15 @@ class TagTest(OptimizationRunner):
         slothy.optimize()
 
 
+class IfElse(OptimizationRunner):
+    def __init__(self):
+        super().__init__("ifelse", base_dir="tests")
+
+    def core(self, slothy):
+        slothy.config.allow_useless_instructions = True
+        slothy.optimize(start="start", end="end")
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexM85r1),
@@ -141,4 +150,5 @@ test_instances = [
     LoopLetp(),
     HintTest(),
     TagTest(),
+    IfElse(),
 ]

--- a/tests/naive/armv8m/ifelse.s
+++ b/tests/naive/armv8m/ifelse.s
@@ -1,0 +1,12 @@
+.equ RCxy_44, 14
+.macro shift x, y
+.if (RCxy_\x\()\y % 2) == 0
+    vshr.u32 q<SHR_l>, q<A_l>, #32-(RCxy_\x\()\y/2)
+.else
+    vshr.u32 q<SHR_h>, q<A_l>, #32-((RCxy_\x\()\y-1)/2)
+.endif
+.endm
+
+start:
+shift 4, 4
+end:

--- a/tests/naive/armv8m/ifelse.s
+++ b/tests/naive/armv8m/ifelse.s
@@ -3,7 +3,7 @@
 .if (RCxy_\x\()\y % 2) == 0
     vshr.u32 q<SHR_l>, q<A_l>, #32-(RCxy_\x\()\y/2)
 .else
-    vshr.u32 q<SHR_h>, q<A_l>, #32-((RCxy_\x\()\y-1)/2)
+    unimp
 .endif
 .endm
 


### PR DESCRIPTION
Adds a test to cover #236. No fix needed @mkannwischer?

Output of the test:
```
.equ RCxy_44, 14
.macro shift x, y
.if (RCxy_\x\()\y % 2) == 0
    vshr.u32 SHR_l, A_l, #32-(RCxy_\x\()\y/2)
.else
    vshr.u32 SHR_h, A_l, #32-((RCxy_\x\()\y-1)/2)
.endif
.endm

        start:
                                           // Instructions:    1
                                           // Expected cycles: 1
                                           // Expected IPC:    1.00
                                           //
                                           // Wall time:     0.02s
                                           // User time:     0.02s
                                           //
                                           // ----- cycle (expected) ------>
                                           // 0                        25
                                           // |------------------------|----
        vshr.u32 q4, q1, #32-(14/2)        // *.............................

                                                // ------ cycle (expected) ------>
                                                // 0                        25
                                                // |------------------------|-----
        // vshr.u32 SHR_l, A_l, #32-(14/2)      // *..............................

        end:
```