### PR TITLE
Remove typing hints configuration option

### DIFF
--- a/examples/naive/armv8m/crt/_example.py
+++ b/examples/naive/armv8m/crt/_example.py
@@ -28,7 +28,6 @@
 import os
 
 from common.OptimizationRunner import OptimizationRunner
-import slothy.targets.arm_v81m.arch_v81m as Arch_Armv81M
 
 SUBFOLDER = os.path.basename(os.path.dirname(__file__)) + "/"
 
@@ -44,14 +43,6 @@ class CRT(OptimizationRunner):
         # Double the loop body to create more interleaving opportunities
         # Basically a tradeoff of code-size vs performance
         slothy.config.sw_pipelining.unroll = 2
-        slothy.config.typing_hints = {
-            "const_prshift": Arch_Armv81M.RegisterType.GPR,
-            "const_shift9": Arch_Armv81M.RegisterType.GPR,
-            "p_inv_mod_q": Arch_Armv81M.RegisterType.GPR,
-            "p_inv_mod_q_tw": Arch_Armv81M.RegisterType.GPR,
-            "mod_p": Arch_Armv81M.RegisterType.GPR,
-            "mod_p_tw": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize()
 
 

--- a/examples/naive/armv8m/dilithium/_example.py
+++ b/examples/naive/armv8m/dilithium/_example.py
@@ -54,15 +54,6 @@ class ntt_dilithium_12_34_56_78(OptimizationRunner):
     def core(self, slothy):
         slothy.config.inputs_are_outputs = True
         slothy.config.sw_pipelining.enabled = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-            "const1": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.config.sw_pipelining.optimize_preamble = True
@@ -70,7 +61,6 @@ class ntt_dilithium_12_34_56_78(OptimizationRunner):
         slothy.optimize_loop("layer56_loop", postamble_label="layer56_loop_end")
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = True
-        slothy.config.typing_hints = {}
         slothy.config.constraints.st_ld_hazard = False
         slothy.optimize_loop("layer78_loop")
         # Optimize seams between loops
@@ -99,15 +89,6 @@ class ntt_dilithium_12(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-            "const1": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
@@ -133,15 +114,6 @@ class ntt_dilithium_34(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-            "const1": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
@@ -167,15 +139,6 @@ class ntt_dilithium_56(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-            "const1": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
@@ -201,7 +164,6 @@ class ntt_dilithium_78(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {}
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
@@ -242,18 +204,6 @@ class ntt_dilithium_123_456_78(OptimizationRunner):
         slothy.config.variable_size = True
         slothy.config.constraints.stalls_first_attempt = 16
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root3": Arch_Armv81M.RegisterType.GPR,
-            "root5": Arch_Armv81M.RegisterType.GPR,
-            "root6": Arch_Armv81M.RegisterType.GPR,
-            "rtmp": Arch_Armv81M.RegisterType.GPR,
-            "rtmp_tw": Arch_Armv81M.RegisterType.GPR,
-            "root2_tw": Arch_Armv81M.RegisterType.GPR,
-            "root3_tw": Arch_Armv81M.RegisterType.GPR,
-            "root5_tw": Arch_Armv81M.RegisterType.GPR,
-            "root6_tw": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.locked_registers = set(
             [f"QSTACK{i}" for i in [4, 5, 6]]
             + [f"ROOT{i}_STACK" for i in [0, 1, 4]]
@@ -279,7 +229,6 @@ class ntt_dilithium_123_456_78(OptimizationRunner):
         slothy.config.constraints.st_ld_hazard = False
         slothy.config.sw_pipelining.enabled = True
         slothy.config.sw_pipelining.halving_heuristic = False
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer78_loop")
 
         if self.cross_loops_optim:
@@ -299,18 +248,6 @@ class ntt_dilithium_123_456_78_symbolic(OptimizationRunner):
         )
 
     def core(self, slothy):
-        slothy.config.typing_hints = {
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root3": Arch_Armv81M.RegisterType.GPR,
-            "root5": Arch_Armv81M.RegisterType.GPR,
-            "root6": Arch_Armv81M.RegisterType.GPR,
-            "rtmp": Arch_Armv81M.RegisterType.GPR,
-            "rtmp_tw": Arch_Armv81M.RegisterType.GPR,
-            "root2_tw": Arch_Armv81M.RegisterType.GPR,
-            "root3_tw": Arch_Armv81M.RegisterType.GPR,
-            "root5_tw": Arch_Armv81M.RegisterType.GPR,
-            "root6_tw": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.sw_pipelining.enabled = True
         slothy.config.constraints.stalls_minimum_attempt = 0
         slothy.config.constraints.stalls_first_attempt = 0
@@ -328,18 +265,9 @@ class intt_dilithium_12_34_56_78(OptimizationRunner):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.optimize_loop("layer56_loop")
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer78_loop")
 
 

--- a/examples/naive/armv8m/kyber/_example.py
+++ b/examples/naive/armv8m/kyber/_example.py
@@ -57,14 +57,6 @@ class ntt_kyber_1_23_45_67(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.inputs_are_outputs = True
         slothy.optimize_loop("layer1_loop")
         slothy.optimize_loop("layer23_loop")
@@ -74,7 +66,6 @@ class ntt_kyber_1_23_45_67(OptimizationRunner):
             slothy.config.timeout = self.timeout
         if "no_trans" in self.var:
             slothy.config.constraints.st_ld_hazard = True
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer67_loop")
 
 
@@ -100,14 +91,6 @@ class ntt_kyber_1(OptimizationRunner):
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer1_loop")
 
 
@@ -133,14 +116,6 @@ class ntt_kyber_23(OptimizationRunner):
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer23_loop")
 
 
@@ -166,14 +141,6 @@ class ntt_kyber_45(OptimizationRunner):
         slothy.config.sw_pipelining.minimize_overlapping = False
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer45_loop")
 
 
@@ -200,7 +167,6 @@ class ntt_kyber_67(OptimizationRunner):
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = False
         slothy.config.constraints.st_ld_hazard = False
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer67_loop")
 
 
@@ -346,18 +312,9 @@ class intt_kyber_1_23_45_67(OptimizationRunner):
 
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer1_loop")
         slothy.optimize_loop("layer23_loop")
         slothy.optimize_loop("layer45_loop")
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer67_loop")
 
 

--- a/examples/naive/armv8m/ntt_256/_example.py
+++ b/examples/naive/armv8m/ntt_256/_example.py
@@ -1,7 +1,6 @@
 import os
 
 from common.OptimizationRunner import OptimizationRunner
-import slothy.targets.arm_v81m.arch_v81m as Arch_Armv81M
 
 SUBFOLDER = os.path.basename(os.path.dirname(__file__)) + "/"
 
@@ -13,17 +12,6 @@ class ntt_n256_l6_s32(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            r: Arch_Armv81M.RegisterType.GPR
-            for r in [
-                "root0",
-                "root1",
-                "root2",
-                "root0_twisted",
-                "root1_twisted",
-                "root2_twisted",
-            ]
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.optimize_loop("layer56_loop")
@@ -36,18 +24,9 @@ class ntt_n256_l8_s32(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.optimize_loop("layer56_loop")
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer78_loop")
 
 
@@ -58,14 +37,6 @@ class intt_n256_l6_s32(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.optimize_loop("layer56_loop")
@@ -78,18 +49,9 @@ class intt_n256_l8_s32(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.optimize_loop("layer56_loop")
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer78_loop")
 
 

--- a/paper/scripts/slothy_ntt_helium.py
+++ b/paper/scripts/slothy_ntt_helium.py
@@ -142,14 +142,6 @@ class ntt_kyber_1_23_45_67(Example):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.variable_size = True
         slothy.config.constraints.stalls_first_attempt = 16
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.inputs_are_outputs = True
         slothy.optimize_loop("layer1_loop")
         slothy.optimize_loop("layer23_loop")
@@ -159,7 +151,6 @@ class ntt_kyber_1_23_45_67(Example):
             slothy.config.timeout = self.timeout
         if "no_trans" in self.var:
             slothy.config.constraints.st_ld_hazard = True
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer67_loop")
 
 
@@ -212,15 +203,6 @@ class ntt_dilithium_12_34_56_78(Example):
         slothy.config.constraints.stalls_first_attempt = 16
         slothy.config.inputs_are_outputs = True
         slothy.config.sw_pipelining.enabled = True
-        slothy.config.typing_hints = {
-            "root0": Arch_Armv81M.RegisterType.GPR,
-            "root1": Arch_Armv81M.RegisterType.GPR,
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root0_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root1_twisted": Arch_Armv81M.RegisterType.GPR,
-            "root2_twisted": Arch_Armv81M.RegisterType.GPR,
-            "const1": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.optimize_loop("layer12_loop")
         slothy.optimize_loop("layer34_loop")
         slothy.config.sw_pipelining.optimize_preamble = True
@@ -228,7 +210,6 @@ class ntt_dilithium_12_34_56_78(Example):
         slothy.optimize_loop("layer56_loop", postamble_label="layer56_loop_end")
         slothy.config.sw_pipelining.optimize_preamble = False
         slothy.config.sw_pipelining.optimize_postamble = True
-        slothy.config.typing_hints = {}
         slothy.config.constraints.st_ld_hazard = False
         slothy.optimize_loop("layer78_loop")
         # Optimize seams between loops
@@ -257,18 +238,6 @@ class ntt_dilithium_123_456_78(Example):
         slothy.config.variable_size = True
         slothy.config.constraints.stalls_first_attempt = 16
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints = {
-            "root2": Arch_Armv81M.RegisterType.GPR,
-            "root3": Arch_Armv81M.RegisterType.GPR,
-            "root5": Arch_Armv81M.RegisterType.GPR,
-            "root6": Arch_Armv81M.RegisterType.GPR,
-            "rtmp": Arch_Armv81M.RegisterType.GPR,
-            "rtmp_tw": Arch_Armv81M.RegisterType.GPR,
-            "root2_tw": Arch_Armv81M.RegisterType.GPR,
-            "root3_tw": Arch_Armv81M.RegisterType.GPR,
-            "root5_tw": Arch_Armv81M.RegisterType.GPR,
-            "root6_tw": Arch_Armv81M.RegisterType.GPR,
-        }
         slothy.config.locked_registers = set(
             [f"QSTACK{i}" for i in [4, 5, 6]]
             + [f"ROOT{i}_STACK" for i in [0, 1, 4]]
@@ -281,7 +250,6 @@ class ntt_dilithium_123_456_78(Example):
         slothy.config.constraints.st_ld_hazard = False
         slothy.config.sw_pipelining.enabled = True
         slothy.config.sw_pipelining.halving_heuristic = False
-        slothy.config.typing_hints = {}
         slothy.optimize_loop("layer78_loop")
 
 

--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -1388,8 +1388,6 @@ class Config(NestedPrint, LockAttributes):
 
         self.mirror_char = "~"
 
-        self.typing_hints = {}
-
         self.solver_random_seed = 42
 
         # TODO: Document log_dir and log_model

--- a/slothy/core/dataflow.py
+++ b/slothy/core/dataflow.py
@@ -343,22 +343,6 @@ class Config:
         return self._arch
 
     @property
-    def typing_hints(self):
-        """A dictionary of 'typing hints' explicitly assigning to symbolic register names
-        a register type.
-
-        This can be necessary to disambiguate the type of symbolic registers.
-        For example, the Helium vector extension has various instructions which
-        accept either vector or GPR arguments.
-        """
-        typing_hints = {
-            name: ty
-            for ty in self.arch.RegisterType
-            for name in self.arch.RegisterType.list_registers(ty, with_variants=True)
-        }
-        return {**self._typing_hints, **typing_hints}
-
-    @property
     def outputs(self):
         """The global outputs of the data flow graph."""
         return self._outputs
@@ -377,10 +361,6 @@ class Config:
         """
         return self._allow_useless_instructions
 
-    @typing_hints.setter
-    def typing_hints(self, val):
-        self._typing_hints = val
-
     @outputs.setter
     def outputs(self, val):
         self._outputs = val
@@ -395,7 +375,6 @@ class Config:
 
     def __init__(self, slothy_config: any = None, **kwargs: any):
         self._arch = None
-        self._typing_hints = None
         self._outputs = None
         self._inputs_are_outputs = None
         self._allow_useless_instructions = None
@@ -411,7 +390,6 @@ class Config:
         self._slothy_config = slothy_config
         self._arch = slothy_config.arch
         self._locked_registers = slothy_config.locked_registers
-        self._typing_hints = self._slothy_config.typing_hints
         self._outputs = self._slothy_config.outputs
         self._inputs_are_outputs = self._slothy_config.inputs_are_outputs
         self._allow_useless_instructions = (
@@ -852,14 +830,6 @@ class DataFlowGraph:
                     expectations.append((f"State dictionary: {exp_ty}", exp_ty))
                 else:
                     self.logger.debug("    + %s not in state dictionary", name)
-                # Check if we've been given a type hint
-                if name in self.config.typing_hints.keys():
-                    exp_ty = self.config.typing_hints[name]
-                    self.logger.debug(
-                        f"   + type of {name} according to typing hints: {exp_ty}"
-                    )
-                    expectations.append((f"Typing hint: {exp_ty}", exp_ty))
-
                 exp_ty = self.arch.RegisterType.find_type(name)
                 if exp_ty is not None:
                     self.logger.debug(

--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -58,7 +58,6 @@ class Example2(OptimizationRunner):
     def core(self, slothy):
         slothy.config.sw_pipelining.enabled = True
         slothy.config.inputs_are_outputs = True
-        slothy.config.typing_hints["const"] = Arch_Armv81M.RegisterType.GPR
         slothy.optimize_loop("start")
 
 


### PR DESCRIPTION
- Solves #235 

Since we introduced typing annotations for symbolic register, e.g., r<tmp> and refactor the MVE model to follow the same approach as for AArch64, we should entirely remove the typing hints from the SLOTHY configuration and all examples.