### PR TITLE
Armv7-M: Fix ldrd_imm

### DIFF
--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -2003,6 +2003,10 @@ class ldrd_imm(Ldrd):
         obj.addr = obj.args_in_out[0]
         return obj
 
+    def write(self):
+        self.immediate = simplify(self.pre_index)
+        return super().write()
+
 
 class ldrd_with_postinc(Ldrd):
     pattern = "ldrd<width> <Ra>, <Rb>, [<Rc>], <imm>"


### PR DESCRIPTION
ldrd_imm uses a pre_index. However, it contains no write method that updates the immediate in case the address offset fixup modified the pre_index. This commit adds the missing write function.

This likely does not have any impact on the examples we have, as for the Cortex-M7, we commonly used the splitting to split an ldrd into two ldrs.