### PR TITLE
Allow disabling unsafe_address_offset_fixup for Armv8-M

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -251,12 +251,6 @@ class Config(NestedPrint, LockAttributes):
 
         .. note::
 
-            For historical reason, this feature cannot be disabled for
-            the Armv8.1-M architecture model. A refactoring of that model is needed
-            to make address offset fixup configurable.
-
-        .. note::
-
             The user-imposed safety constraint is not a necessity -- in principle,
             SLOTHY could detect when it is safe to reorder ldr/str instructions with
             increment.
@@ -1485,8 +1479,6 @@ class Config(NestedPrint, LockAttributes):
 
     @unsafe_address_offset_fixup.setter
     def unsafe_address_offset_fixup(self, val):
-        if val is False and self.arch.arch_name == "Arm_v81M":
-            raise InvalidConfig("unsafe address offset fixup must be set for Armv8.1-M")
         self._unsafe_address_offset_fixup = val
 
     @locked_registers.setter

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -1109,29 +1109,29 @@ class ldrd_no_imm(MVEInstruction):
 
 class ldrd_with_writeback(MVEInstruction):
     pattern = "ldrd <Rt0>, <Rt1>, [<Rn>, <imm>]!"
-    inputs = ["Rn"]
     outputs = ["Rt0", "Rt1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class ldrd_with_post(MVEInstruction):
     pattern = "ldrd <Rt0>, <Rt1>, [<Rn>], <imm>"
-    inputs = ["Rn"]
     outputs = ["Rt0", "Rt1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1155,29 +1155,29 @@ class ldr(MVEInstruction):
 
 class ldr_with_writeback(MVEInstruction):
     pattern = "ldr <Rt>, [<Rn>, <imm>]!"
-    inputs = ["Rn"]
     outputs = ["Rt"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class ldr_with_post(MVEInstruction):
     pattern = "ldr <Rt>, [<Rn>], <imm>"
-    inputs = ["Rn"]
     outputs = ["Rt"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1200,27 +1200,29 @@ class strd(MVEInstruction):
 
 class strd_with_writeback(MVEInstruction):
     pattern = "strd <Rt0>, <Rt1>, [<Rn>, <imm>]!"
-    inputs = ["Rt0", "Rt1", "Rn"]
+    inputs = ["Rt0", "Rt1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[2]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class strd_with_post(MVEInstruction):
     pattern = "strd <Rt0>, <Rt1>, [<Rn>], <imm>"
-    inputs = ["Rt0", "Rt1", "Rn"]
+    inputs = ["Rt0", "Rt1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[2]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1243,7 +1245,6 @@ class vshlc(MVEInstruction):
 
 class vmov_imm(MVEInstruction):
     pattern = "vmov.<dt> <Qd>, <imm>"
-    inputs = []
     outputs = ["Qd"]
 
 
@@ -1279,13 +1280,11 @@ class mov(MVEInstruction):
 
 class mov_imm(MVEInstruction):
     pattern = "mov <Rd>, <imm>"
-    inputs = []
     outputs = ["Rd"]
 
 
 class mvn_imm(MVEInstruction):
     pattern = "mvn <Rd>, <imm>"
-    inputs = []
     outputs = ["Rd"]
 
 
@@ -1523,26 +1522,28 @@ class vstrw_no_imm(MVEInstruction):
 
 class vstrw_with_writeback(MVEInstruction):
     pattern = "vstrw.<dt> <Qd>, [<Rn>, <imm>]!"
-    inputs = ["Qd", "Rn"]
+    inputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[1]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class vstrw_with_post(MVEInstruction):
     pattern = "vstrw.<dt> <Qd>, [<Rn>], <imm>"
-    inputs = ["Qd", "Rn"]
+    inputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
-        obj.addr = obj.args_in[1]
+        obj.addr = obj.args_in_out[0]
         obj.pre_index = None
         return obj
 
@@ -1613,29 +1614,29 @@ class vldrb_no_imm(MVEInstruction):
 
 class vldrb_with_writeback(MVEInstruction):
     pattern = "vldrb.<dt> <Qd>, [<Rn>, <imm>]!"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class vldrb_with_post(MVEInstruction):
     pattern = "vldrb.<dt> <Qd>, [<Rn>], <imm>"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1679,29 +1680,29 @@ class vldrh_no_imm(MVEInstruction):
 
 class vldrh_with_writeback(MVEInstruction):
     pattern = "vldrh.<dt> <Qd>, [<Rn>, <imm>]!"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class vldrh_with_post(MVEInstruction):
     pattern = "vldrh.<dt> <Qd>, [<Rn>], <imm>"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1745,29 +1746,29 @@ class vldrw_no_imm(MVEInstruction):
 
 class vldrw_with_writeback(MVEInstruction):
     pattern = "vldrw.<dt> <Qd>, [<Rn>, <imm>]!"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
 class vldrw_with_post(MVEInstruction):
     pattern = "vldrw.<dt> <Qd>, [<Rn>], <imm>"
-    inputs = ["Rn"]
     outputs = ["Qd"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         return obj
 
 
@@ -1895,8 +1896,8 @@ class vld21(MVEInstruction):
 
 class vld20_with_writeback(MVEInstruction):
     pattern = "vld20.<dt> {<Qd0>, <Qd1>}, [<Rn>]!"
-    inputs = ["Rn"]
     outputs = ["Qd0", "Qd1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
@@ -1904,20 +1905,19 @@ class vld20_with_writeback(MVEInstruction):
         obj.args_out_combinations = [
             ([0, 1], [[f"q{i}", f"q{i+1}"] for i in range(0, 7)])
         ]
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 32
         return obj
 
 
 class vld21_with_writeback(MVEInstruction):
     pattern = "vld21.<dt> {<Qd0>, <Qd1>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1"]
+    in_outs = ["Rn", "Qd0", "Qd1"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 32
         return obj
 
@@ -1993,8 +1993,8 @@ class vld43(MVEInstruction):
 
 class vld40_with_writeback(MVEInstruction):
     pattern = "vld40.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
     outputs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
@@ -2005,7 +2005,7 @@ class vld40_with_writeback(MVEInstruction):
                 [[f"q{i}", f"q{i+1}", f"q{i+2}", f"q{i+3}"] for i in range(0, 5)],
             )
         ]
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2013,13 +2013,12 @@ class vld40_with_writeback(MVEInstruction):
 
 class vld41_with_writeback(MVEInstruction):
     pattern = "vld41.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2027,13 +2026,12 @@ class vld41_with_writeback(MVEInstruction):
 
 class vld42_with_writeback(MVEInstruction):
     pattern = "vld42.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2041,13 +2039,12 @@ class vld42_with_writeback(MVEInstruction):
 
 class vld43_with_writeback(MVEInstruction):
     pattern = "vld43.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2088,28 +2085,28 @@ class vst21(MVEInstruction):
 
 class vst20_with_writeback(MVEInstruction):
     pattern = "vst20.<dt> {<Qd0>, <Qd1>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1"]
+    in_outs = ["Rn", "Qd0", "Qd1"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 32
         return obj
 
 
 class vst21_with_writeback(MVEInstruction):
     pattern = "vst21.<dt> {<Qd0>, <Qd1>}, [<Rn>]!"
-    inputs = ["Rn", "Qd0", "Qd1"]
+    inputs = ["Qd0", "Qd1"]
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.args_in_combinations = [
-            ([1, 2], [[f"q{i}", f"q{i+1}"] for i in range(0, 7)])
+            ([0, 1], [[f"q{i}", f"q{i+1}"] for i in range(0, 7)])
         ]
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 32
 
         return obj
@@ -2179,13 +2176,12 @@ class vst43(MVEInstruction):
 
 class vst40_with_writeback(MVEInstruction):
     pattern = "vst40.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2193,13 +2189,12 @@ class vst40_with_writeback(MVEInstruction):
 
 class vst41_with_writeback(MVEInstruction):
     pattern = "vst41.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2207,13 +2202,12 @@ class vst41_with_writeback(MVEInstruction):
 
 class vst42_with_writeback(MVEInstruction):
     pattern = "vst42.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn"]
-    in_outs = ["Qd0", "Qd1", "Qd2", "Qd3"]
+    in_outs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj
@@ -2221,20 +2215,20 @@ class vst42_with_writeback(MVEInstruction):
 
 class vst43_with_writeback(MVEInstruction):
     pattern = "vst43.<dt> {<Qd0>, <Qd1>, <Qd2>, <Qd3>}, [<Rn>]!"
-    inputs = ["Rn", "Qd0", "Qd1", "Qd2", "Qd3"]
+    inputs = ["Qd0", "Qd1", "Qd2", "Qd3"]
     outputs = []
-    in_outs = []
+    in_outs = ["Rn"]
 
     @classmethod
     def make(cls, src):
         obj = MVEInstruction.build(cls, src)
         obj.args_in_combinations = [
             (
-                [1, 2, 3, 4],
+                [0, 1, 2, 3],
                 [[f"q{i}", f"q{i+1}", f"q{i+2}", f"q{i+3}"] for i in range(0, 5)],
             )
         ]
-        obj.addr = obj.args_in[0]
+        obj.addr = obj.args_in_out[0]
         obj.increment = 64
 
         return obj

--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -46,6 +46,11 @@ class Example0(OptimizationRunner):
     def __init__(self):
         super().__init__("simple0", base_dir="tests")
 
+    def core(self, slothy):
+        slothy.config.unsafe_address_offset_fixup = False
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize()
+
 
 class Example1(OptimizationRunner):
     def __init__(self):


### PR DESCRIPTION
This PR implements issue #243 by enabling the ability to disable `unsafe_address_offset_fixup` for ARM v8.1-M architecture targets.