### PR TITLE
Armv8.1-M: Allow use of sp/r13

### DIFF
--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -83,7 +83,7 @@ class RegisterType(Enum):
             "RPTR_STACK",
         ]
 
-        gprs_normal = [f"r{i}" for i in range(13)] + ["r14"]
+        gprs_normal = [f"r{i}" for i in range(15)]
         vregs_normal = [f"q{i}" for i in range(8)]
 
         gprs_extra = [f"r{i}_EXT" for i in range(16)]
@@ -123,11 +123,11 @@ class RegisterType(Enum):
         }.get(string, None)
 
     def default_aliases():
-        return {"lr": "r14"}
+        return {"lr": "r14", "sp": "r13"}
 
     def default_reserved():
         """Return the list of registers that should be reserved by default"""
-        return set(["r14"])
+        return set(["r13", "r14"])
 
 
 class LeLoop(Loop):

--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -36,6 +36,9 @@ class Instructions(OptimizationRunner):
 
     def core(self, slothy):
         slothy.config.allow_useless_instructions = True
+        slothy.config.constraints.allow_reordering = False
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 256
         slothy.optimize(start="start", end="end")
 
 

--- a/tests/naive/armv8m/instructions.s
+++ b/tests/naive/armv8m/instructions.s
@@ -5,6 +5,9 @@ add r0, r1, r2
 
 sub r0, r1, r2
 
+ldr r0, [sp, #4]
+ldr r1, [r13, #8]
+
 vmulh.u8 q2, q0, q1
 vmulh.u16 q2, q0, q1
 vmulh.u32 q2, q0, q1


### PR DESCRIPTION
- Implements modeling of r13 as a GPR with sp alias
- Resolves https://github.com/slothy-optimizer/slothy/issues/238