### PR TITLE
Add multiply long instructions neon 

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3243,6 +3243,68 @@ class vsmull2(Vmull):
     outputs = ["Vd"]
 
 
+class vumull_lane(Vmull):
+    pattern = "umull <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[0] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+class vumull2_lane(Vmull):
+    pattern = "umull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[0] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+class vsmull_lane(Vmull):
+    pattern = "smull <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[0] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+class vsmull2_lane(Vmull):
+    pattern = "smull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    outputs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[0] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+
 class Vmlal(AArch64Instruction):
     pass
 
@@ -3252,7 +3314,11 @@ class vumlal(Vmlal):
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
 
-
+class vumlal2(Vmlal):
+    pattern = "umlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+    
 class vsmlal(Vmlal):
     pattern = "smlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
@@ -3265,10 +3331,66 @@ class vsmlal2(Vmlal):
     in_outs = ["Vd"]
 
 
-class vumlal2(Vmlal):
-    pattern = "umlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+class vumlal_lane(Vmlal):
+    pattern = "umlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
+    
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+class vumlal2_lane(Vmlal):
+    pattern = "umlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+    
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+class vsmlal_lane(Vmlal):
+    pattern = "smlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+    
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+  
+class vsmlal2_lane(Vmlal):
+    pattern = "smlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+    
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
 
 
 class VShiftImmediateBasic(AArch64Instruction):

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3399,23 +3399,6 @@ class vsmlal2_lane(Vmlal):
         return obj
 
 
-# comment by Cesare Huang: according to SWOG a72 (and a76) and SWOG a55
-# umlal umlsl smull and smlsl instructions are classified as
-# "ASIMD multiply accumulate long" instructions, and they also share
-# the same forwarding mechanism in pipeline.
-# Also, the websites https://dougallj.github.io/applecpu/firestorm-simd.html
-# and https://dougallj.github.io/applecpu/icestorm-simd.html
-# suggest that these instructions (umlal umlsl smull and smlsl)
-# have the exactly same paramters (latency, throughput, etc.) for respective {fire, ice}storm core.
-# so here we treat these instructions as a subclass of Vmlal.
-# References:
-# SWOG a72: page 25
-# SWOG a76: page 26
-# SWOG a55: page 35
-# https://dougallj.github.io/applecpu/firestorm-simd.html
-# https://dougallj.github.io/applecpu/icestorm-simd.html
-
-
 class vumlsl(Vmlal):
     pattern = "umlsl <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3258,6 +3258,7 @@ class vumull_lane(Vmull):
             ]
         return obj
 
+
 class vumull2_lane(Vmull):
     pattern = "umull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
@@ -3273,6 +3274,7 @@ class vumull2_lane(Vmull):
             ]
         return obj
 
+
 class vsmull_lane(Vmull):
     pattern = "smull <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
@@ -3287,6 +3289,7 @@ class vsmull_lane(Vmull):
                 [f"v{i}" for i in range(0, 16)],
             ]
         return obj
+
 
 class vsmull2_lane(Vmull):
     pattern = "smull2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
@@ -3304,7 +3307,6 @@ class vsmull2_lane(Vmull):
         return obj
 
 
-
 class Vmlal(AArch64Instruction):
     pass
 
@@ -3314,11 +3316,13 @@ class vumlal(Vmlal):
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
 
+
 class vumlal2(Vmlal):
     pattern = "umlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
-    
+
+
 class vsmlal(Vmlal):
     pattern = "smlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
     inputs = ["Va", "Vb"]
@@ -3335,7 +3339,7 @@ class vumlal_lane(Vmlal):
     pattern = "umlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
-    
+
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
@@ -3346,11 +3350,12 @@ class vumlal_lane(Vmlal):
             ]
         return obj
 
+
 class vumlal2_lane(Vmlal):
     pattern = "umlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
-    
+
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
@@ -3366,7 +3371,7 @@ class vsmlal_lane(Vmlal):
     pattern = "smlal <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
-    
+
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
@@ -3376,12 +3381,118 @@ class vsmlal_lane(Vmlal):
                 [f"v{i}" for i in range(0, 16)],
             ]
         return obj
-  
+
+
 class vsmlal2_lane(Vmlal):
     pattern = "smlal2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
     inputs = ["Va", "Vb"]
     in_outs = ["Vd"]
-    
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+# comment by Cesare Huang: according to SWOG a72 (and a76) and SWOG a55
+# umlal umlsl smull and smlsl instructions are classified as
+# "ASIMD multiply accumulate long" instructions, and they also share
+# the same forwarding mechanism in pipeline.
+# Also, the websites https://dougallj.github.io/applecpu/firestorm-simd.html
+# and https://dougallj.github.io/applecpu/icestorm-simd.html
+# suggest that these instructions (umlal umlsl smull and smlsl)
+# have the exactly same paramters (latency, throughput, etc.) for respective {fire, ice}storm core.
+# so here we treat these instructions as a subclass of Vmlal.
+# References:
+# SWOG a72: page 25
+# SWOG a76: page 26
+# SWOG a55: page 35
+# https://dougallj.github.io/applecpu/firestorm-simd.html
+# https://dougallj.github.io/applecpu/icestorm-simd.html
+
+
+class vumlsl(Vmlal):
+    pattern = "umlsl <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+
+class vumlsl2(Vmlal):
+    pattern = "umlsl2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+
+class vsmlsl(Vmlal):
+    pattern = "smlsl <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+
+class vsmlsl2(Vmlal):
+    pattern = "smlsl2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+
+class vumlsl_lane(Vmlal):
+    pattern = "umlsl <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+class vumlsl2_lane(Vmlal):
+    pattern = "umlsl2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "8h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+class vsmlsl_lane(Vmlal):
+    pattern = "smlsl <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        if obj.datatype[1] == "4h":
+            obj.args_in_restrictions = [
+                [f"v{i}" for i in range(0, 32)],
+                [f"v{i}" for i in range(0, 16)],
+            ]
+        return obj
+
+
+class vsmlsl2_lane(Vmlal):
+    pattern = "smlsl2 <Vd>.<dt0>, <Va>.<dt1>, <Vb>.<dt2>[<index>]"
+    inputs = ["Va", "Vb"]
+    in_outs = ["Vd"]
+
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3251,7 +3251,7 @@ class vumull_lane(Vmull):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[0] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3267,7 +3267,7 @@ class vumull2_lane(Vmull):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[0] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3283,7 +3283,7 @@ class vsmull_lane(Vmull):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[0] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3299,7 +3299,7 @@ class vsmull2_lane(Vmull):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[0] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3343,7 +3343,7 @@ class vumlal_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3359,7 +3359,7 @@ class vumlal2_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3375,7 +3375,7 @@ class vsmlal_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3391,7 +3391,7 @@ class vsmlal2_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3431,7 +3431,7 @@ class vumlsl_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3447,7 +3447,7 @@ class vumlsl2_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3463,7 +3463,7 @@ class vsmlsl_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "4h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],
@@ -3479,7 +3479,7 @@ class vsmlsl2_lane(Vmlal):
     @classmethod
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
-        if obj.datatype[1] == "8h":
+        if obj.datatype[0] == "4s":
             obj.args_in_restrictions = [
                 [f"v{i}" for i in range(0, 32)],
                 [f"v{i}" for i in range(0, 16)],

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -45,6 +45,14 @@ smlal v6.4s, v7.4h, v8.h[3]
 smlal2 v9.4s, v10.8h, v11.8h
 smlal2 v9.4s, v10.8h, v11.h[2]
 
+umlsl v3.4s, v4.4h, v5.4h
+umlsl v3.4s, v4.4h, v5.h[0]
+umlsl2 v12.4s, v13.8h, v14.8h
+umlsl2 v12.4s, v13.8h, v14.h[0]
+smlsl v6.4s, v7.4h, v8.4h
+smlsl v6.4s, v7.4h, v8.h[3]
+smlsl2 v9.4s, v10.8h, v11.8h
+smlsl2 v9.4s, v10.8h, v11.h[2]
 
 pmull v4.1q, v5.1d, v6.1d
 pmull2 v7.1q, v8.2d, v9.2d

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -24,14 +24,28 @@ trn1 v17.16b, v18.16b, v19.16b
 trn2 v20.16b, v21.16b, v22.16b
 aese v0.16b, v1.16b
 aesmc v2.16b, v3.16b
+
+// ASIMD multiply long 
 umull v23.4s, v24.4h, v25.4h
 umull2 v26.4s, v27.8h, v28.8h
+umull v11.4s, v12.4h, v13.h[0]
+umull2 v11.4s, v12.8h, v13.h[1]
 smull v29.4s, v30.4h, v31.4h
 smull2 v0.4s, v1.8h, v2.8h
+smull v11.4s, v12.4h, v13.h[0]
+smull2 v11.4s, v12.8h, v13.h[3]
+
+// ASIMD multiply accumulate long
 umlal v3.4s, v4.4h, v5.4h
-smlal v6.4s, v7.4h, v8.4h
-smlal2 v9.4s, v10.8h, v11.8h
+umlal v3.4s, v4.4h, v5.h[0]
 umlal2 v12.4s, v13.8h, v14.8h
+umlal2 v12.4s, v13.8h, v14.h[0]
+smlal v6.4s, v7.4h, v8.4h
+smlal v6.4s, v7.4h, v8.h[3]
+smlal2 v9.4s, v10.8h, v11.8h
+smlal2 v9.4s, v10.8h, v11.h[2]
+
+
 pmull v4.1q, v5.1d, v6.1d
 pmull2 v7.1q, v8.2d, v9.2d
 


### PR DESCRIPTION
Adds the following parser definitions and corresponding tests in instructions.s

vumull{2}_lane
vsmull{2}_lane

vumlal{2}_lane
vsmlal{2}_lane

vumlsl{2} (vector)
vsmlsl{2} (vector)
vumlsl{2}_lane
vsmlsl{2}_lane

I put the last four instructions (vumlsl{2}, vsmlsl{2}, vumlsl{2}_lane, vumlsl{2}_lane ) into the class Vml"a"l. The reason is:

Major micro-architecture references (ARM SWOG docs and Apple core micro-benchmarks) indicate that these ops share the same execution and forwarding behaviour as existing Vmlal family members.

ARM SWOG A72 (p25) ARM SWOG A76 (p26) ARM SWOG A55 (p35) group the instructions umlal{2}, smlal{2}, umlsl{2}, smlsl{2} into "ASIMD Multiply Accumulate Long" instruction groups

The websites
https://dougallj.github.io/applecpu/firestorm-simd.html
https://dougallj.github.io/applecpu/icestorm-simd.html
also indicate that these instructions (umlal{2}, smlal{2}, umlsl{2}, smlsl{2}) have the same parameters (latency, throughput, etc.) for respective {fire, ice}storm cores.

So here we treat these instructions as the subclass Vmlal.
