### PR TITLE
AArch64: add `s` register support and add `fmov` and `uaddlv` instructions

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -834,7 +834,7 @@ class AArch64Instruction(Instruction):
                 f"<(?P<symbol_{g.group(1)}{g.group(2)}>\\w+)>))"
             )
 
-        src = re.sub(r"<([BHWXVQTD])(\w+)>", pattern_transform, src)
+        src = re.sub(r"<([BHWXVQTDS])(\w+)>", pattern_transform, src)
 
         # Replace <key> or <key0>, <key1>, ... with pattern
         def replace_placeholders(src, mnemonic_key, regexp, group_name):
@@ -923,7 +923,7 @@ class AArch64Instruction(Instruction):
     def __infer_register_type(ptrn):
         if ptrn[0].upper() in ["X", "W"]:
             return RegisterType.GPR
-        if ptrn[0].upper() in ["V", "Q", "D", "B"]:
+        if ptrn[0].upper() in ["V", "Q", "D", "S", "B"]:
             return RegisterType.NEON
         if ptrn[0].upper() in ["T"]:
             return RegisterType.HINT

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -4367,6 +4367,12 @@ class cmlt(ASimdCompare):
     outputs = ["Vd"]
 
 
+class vuaddlv_sform(AArch64Instruction):
+    pattern = "uaddlv <Sd>, <Va>.<dt>"
+    inputs = ["Va"]
+    outputs = ["Sd"]
+
+
 class Spill:
     def spill(reg, loc):
         return f"str {reg}, [sp, #STACK_LOC_{loc}]"

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3630,6 +3630,12 @@ class Fmov(AArch64Instruction):
     pass
 
 
+class fmov_s_form(Fmov):
+    pattern = "fmov <Wd>, <Sa>"
+    inputs = ["Sa"]
+    outputs = ["Wd"]
+
+
 class fmov_0(Fmov):
     pattern = "fmov <Dd>, <Xa>"
     inputs = ["Xa"]

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -159,6 +159,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     AArch64NeonShiftInsert,
     vtbl,
     sub_imm,
+    vuaddlv_sform,
 )
 
 issue_rate = 2
@@ -259,6 +260,7 @@ execution_units = {
         VShiftImmediateRounding,
         AArch64NeonLogical,
         sub_imm,
+        vuaddlv_sform,
     ): [
         [ExecutionUnit.VEC0, ExecutionUnit.VEC1]
     ],  # these instructions use both VEC0 and VEC1
@@ -425,6 +427,7 @@ inverse_throughput = {
         Vmull,
         Vmlal,
         umov_d,
+        vuaddlv_sform,
     ): 1,
     sub_imm: 1,
     (vshl, vshl_d, vsshr, vushr, vuxtl): 1,
@@ -526,6 +529,7 @@ default_latencies = {
     (ldr_sxtw_wform): 5,
     (lsr, lsr_wform): 1,
     (umull_wform, mul_wform, umaddl_wform): 3,
+    (vuaddlv_sform): 3,
     (and_imm, and_imm_wform): 1,
     (add2, add_lsr, add_lsl, add_sp_imm): 2,
     (

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -160,6 +160,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     vtbl,
     sub_imm,
     vuaddlv_sform,
+    fmov_s_form,  # from double/single to gen reg
 )
 
 issue_rate = 2
@@ -259,7 +260,6 @@ execution_units = {
         vtbl,
         VShiftImmediateRounding,
         AArch64NeonLogical,
-        sub_imm,
         vuaddlv_sform,
     ): [
         [ExecutionUnit.VEC0, ExecutionUnit.VEC1]
@@ -317,6 +317,7 @@ execution_units = {
         d_ldr_stack_with_inc,
         q_ldr1_stack,
         Q_Ld2_Lane_Post_Inc,
+        fmov_s_form,  # from double/single to gen reg
     ): [
         ExecutionUnit.VEC0,
         ExecutionUnit.VEC1,
@@ -397,6 +398,7 @@ execution_units = {
         tst_wform,
         movk_imm,
         sub,
+        sub_imm,
         sbcs_zero_to_zero,
         cmp_xzr2,
         mov,
@@ -484,6 +486,7 @@ inverse_throughput = {
     (eor_wform): 1,
     (eor, bic, eor_ror, bic_ror): 1,
     AESInstruction: 1,
+    fmov_s_form: 1,  # from double/single to gen reg
 }
 
 default_latencies = {
@@ -568,6 +571,7 @@ default_latencies = {
     # NOTE: AESE/AESMC and AESD/AESIMC pairs can be dual-issued on A55 but this
     # is not modeled
     AESInstruction: 2,
+    fmov_s_form: 1,  # from double/single to gen reg
 }
 
 

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -102,6 +102,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     vtbl,
     sub_imm,
     vuaddlv_sform,
+    fmov_s_form,  # from vec to gen reg
 )
 
 # From the A72 SWOG, Section "4.1 Dispatch Constraints"
@@ -214,6 +215,7 @@ execution_units = {
         [ExecutionUnit.ASIMD1, ExecutionUnit.LOAD0, ExecutionUnit.LOAD1],
     ],
     AESInstruction: [ExecutionUnit.ASIMD0],
+    fmov_s_form: ExecutionUnit.LOAD(),  # from vec to gen reg
 }
 
 inverse_throughput = {
@@ -252,6 +254,7 @@ inverse_throughput = {
     AESInstruction: 1,
     sub_imm: 1,
     vuaddlv_sform: 1,
+    fmov_s_form: 1,  # from vec to gen reg
 }
 
 # REVISIT
@@ -298,6 +301,7 @@ default_latencies = {
     AESInstruction: 3,
     sub_imm: 3,
     vuaddlv_sform: 6,  # 8B/8H
+    fmov_s_form: 5,  # from vec to gen reg
 }
 
 

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -101,6 +101,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     AArch64NeonShiftInsert,
     vtbl,
     sub_imm,
+    vuaddlv_sform,
 )
 
 # From the A72 SWOG, Section "4.1 Dispatch Constraints"
@@ -198,6 +199,8 @@ execution_units = {
         ExecutionUnit.ASIMD1,
     ],
     AArch64NeonShiftInsert: [ExecutionUnit.ASIMD1],
+    # 8B/8H occupies both F0, F1
+    vuaddlv_sform: [[ExecutionUnit.ASIMD0, ExecutionUnit.ASIMD1]],
     Vins: [ExecutionUnit.ASIMD0, ExecutionUnit.ASIMD1],
     umov_d: ExecutionUnit.LOAD(),  # ???
     (Ldr_Q, Ldr_X): ExecutionUnit.LOAD(),
@@ -248,6 +251,7 @@ inverse_throughput = {
     vtbl: 1,  # SWOG contains a blank throughput (approximating from AArch32)
     AESInstruction: 1,
     sub_imm: 1,
+    vuaddlv_sform: 1,
 }
 
 # REVISIT
@@ -293,6 +297,7 @@ default_latencies = {
     vtbl: 6,  # q-form: 3*N+3 cycles (N = number of registers in the table)
     AESInstruction: 3,
     sub_imm: 3,
+    vuaddlv_sform: 6,  # 8B/8H
 }
 
 

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -93,6 +93,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     AArch64NeonShiftInsert,
     vtbl,
     sub_imm,
+    vuaddlv_sform,
 )
 
 issue_rate = 4
@@ -213,6 +214,8 @@ execution_units = {
     (AArch64HighMultiply, AArch64Multiply): ExecutionUnit.M(),
     vdup: ExecutionUnit.M(),
     sub_imm: ExecutionUnit.V(),
+    # 8B/8H occupies both V0, V1
+    vuaddlv_sform: [[ExecutionUnit.VEC0, ExecutionUnit.VEC1]],
 }
 
 inverse_throughput = {
@@ -256,6 +259,7 @@ inverse_throughput = {
     (vdup): 1,
     umull_wform: 1,
     sub_imm: 1,
+    vuaddlv_sform: 1,  # 8B/8H
 }
 
 default_latencies = {
@@ -301,6 +305,7 @@ default_latencies = {
     umull_wform: 2,
     vtbl: 2,
     sub_imm: 2,
+    vuaddlv_sform: 5,  # 8B/8H
 }
 
 

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -94,6 +94,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     vtbl,
     sub_imm,
     vuaddlv_sform,
+    fmov_s_form,  # from vec to gen reg
 )
 
 issue_rate = 4
@@ -210,6 +211,7 @@ execution_units = {
     Tst: ExecutionUnit.I(),
     AArch64ShiftedArithmetic: ExecutionUnit.M(),
     Fmov: ExecutionUnit.M(),
+    fmov_s_form: ExecutionUnit.V1(),  # from vec to gen reg
     umull_wform: ExecutionUnit.M(),
     (AArch64HighMultiply, AArch64Multiply): ExecutionUnit.M(),
     vdup: ExecutionUnit.M(),
@@ -254,6 +256,7 @@ inverse_throughput = {
     AArch64ShiftedArithmetic: 1,
     Tst: 1,
     Fmov: 1,
+    fmov_s_form: 1,  # from vec to gen reg
     (AArch64HighMultiply): 4,
     (AArch64Multiply): 3,
     (vdup): 1,
@@ -299,6 +302,7 @@ default_latencies = {
     AArch64ShiftedArithmetic: 2,
     Tst: 1,
     Fmov: 3,
+    fmov_s_form: 2,  # from vec to gen reg
     AArch64HighMultiply: 5,
     AArch64Multiply: 4,
     (vdup): 3,

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -39,6 +39,7 @@ ldr q24, [x3, x12, lsl #4]
 clz v0.16b, v0.16b
 cnt v0.16b, v0.16b
 tbl v16.16b, {v16.16b}, v24.16b
+fmov w12, s20
 
 // ASIMD multiply long 
 umull v23.4s, v24.4h, v25.4h

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -72,4 +72,6 @@ smlsl2 v9.4s, v10.8h, v11.h[2]
 pmull v4.1q, v5.1d, v6.1d
 pmull2 v7.1q, v8.2d, v9.2d
 
+uaddlv s20, v4.8h
+
 end:


### PR DESCRIPTION
This PR
- [X] Extends the AArch64 model to support the s register aliases
- [X] Adds `uaddlv` support to the AArch64 model and A55/A72/N1 uArch models
- [x] Adds  `fmov` support to the AArch64 model and A55/A72/N1 uArch models
- Related to #279 