### PR TITLE
Add support for non-power-of-2 unroll factors and support unrolling with unknown iteration count. 

### DIFF
--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -249,6 +249,9 @@ class AArch64UnknownIter(OptimizationRunner):
         slothy.config.sw_pipelining.unroll = 3
         slothy.config.sw_pipelining.unknown_iteration_count = True
         slothy.config.inputs_are_outputs = True
+        current_reserved = slothy.config.reserved_regs.copy()
+        current_reserved.add("x2")
+        slothy.config.reserved_regs = current_reserved
         slothy.optimize_loop("start")
 
 
@@ -267,6 +270,9 @@ class AArch64UnknownIterPow2(OptimizationRunner):
         slothy.config.sw_pipelining.unroll = 4
         slothy.config.sw_pipelining.unknown_iteration_count = True
         slothy.config.inputs_are_outputs = True
+        current_reserved = slothy.config.reserved_regs.copy()
+        current_reserved.add("x2")
+        slothy.config.reserved_regs = current_reserved
         slothy.optimize_loop("start")
 
 

--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -234,6 +234,42 @@ class AArch64Ubfx(OptimizationRunner):
         slothy.optimize()
 
 
+class AArch64UnknownIter(OptimizationRunner):
+    def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
+        name = "aarch64_unknown_iter"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.unroll = 3
+        slothy.config.sw_pipelining.unknown_iteration_count = True
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize_loop("start")
+
+
+class AArch64UnknownIterPow2(OptimizationRunner):
+    def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
+        name = "aarch64_unknown_iter_pow2"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.unroll = 4
+        slothy.config.sw_pipelining.unknown_iteration_count = True
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize_loop("start")
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexA72),
@@ -253,4 +289,6 @@ test_instances = [
     AArch64LoopSubs(),
     AArch64LoopSubTabs(),
     AArch64Ubfx(),
+    AArch64UnknownIter(),
+    AArch64UnknownIterPow2(),
 ]

--- a/tests/naive/aarch64/aarch64_unknown_iter.s
+++ b/tests/naive/aarch64/aarch64_unknown_iter.s
@@ -1,0 +1,12 @@
+count .req x2
+
+// Simple loop for testing unknown iteration count with non-power-of-2 unrolling
+// This should trigger tail section generation when unroll > 1
+start:
+    add x5, x5, x4
+    add x7, x5, x1
+    ldr x5, [x0, #8]
+    add x5, x5, x7
+
+    subs count, count, #1
+    b.gt start

--- a/tests/naive/aarch64/aarch64_unknown_iter_pow2.s
+++ b/tests/naive/aarch64/aarch64_unknown_iter_pow2.s
@@ -1,0 +1,12 @@
+count .req x2
+
+// Simple loop for testing unknown iteration count with power-of-2 unrolling
+// This should trigger tail section generation when unroll > 1
+start:
+    add x5, x5, x4
+    add x7, x5, x1
+    ldr x5, [x0, #8]
+    add x5, x5, x7
+
+    subs count, count, #1
+    b.gt start

--- a/tests/naive/armv7m/_test.py
+++ b/tests/naive/armv7m/_test.py
@@ -61,6 +61,24 @@ class Armv7mExample0Func(OptimizationRunner):
         slothy.global_selftest("my_func", {"r0": 1024})
 
 
+class Armv7mUnknownIter(OptimizationRunner):
+    def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
+        name = "test_unknown_iter"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.unroll = 3
+        slothy.config.sw_pipelining.unknown_iteration_count = True
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize_loop("start")
+
+
 class Armv7mLoopSubs(OptimizationRunner):
     def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
         name = "loop_subs"
@@ -123,6 +141,24 @@ class Armv7mLoopVmovCmpForced(OptimizationRunner):
         slothy.optimize_loop("start", forced_loop_type=Arch_Armv7M.CmpLoop)
 
 
+class Armv7mUnknownIterPow2(OptimizationRunner):
+    def __init__(self, var="", arch=Arch_Armv7M, target=Target_CortexM7):
+        name = "test_unknown_iter_pow2"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.unroll = 4
+        slothy.config.sw_pipelining.unknown_iteration_count = True
+        slothy.config.inputs_are_outputs = True
+        slothy.optimize_loop("start")
+
+
 test_instances = [
     Armv7mLoopSubs(),
     Armv7mLoopCmp(),
@@ -130,4 +166,6 @@ test_instances = [
     Armv7mLoopVmovCmpForced(),
     Armv7mExample0(),
     Armv7mExample0Func(),
+    Armv7mUnknownIter(),
+    Armv7mUnknownIterPow2(),
 ]

--- a/tests/naive/armv7m/_test.py
+++ b/tests/naive/armv7m/_test.py
@@ -76,6 +76,9 @@ class Armv7mUnknownIter(OptimizationRunner):
         slothy.config.sw_pipelining.unroll = 3
         slothy.config.sw_pipelining.unknown_iteration_count = True
         slothy.config.inputs_are_outputs = True
+        current_reserved = slothy.config.reserved_regs.copy()
+        current_reserved.add("r2")
+        slothy.config.reserved_regs = current_reserved
         slothy.optimize_loop("start")
 
 
@@ -156,6 +159,9 @@ class Armv7mUnknownIterPow2(OptimizationRunner):
         slothy.config.sw_pipelining.unroll = 4
         slothy.config.sw_pipelining.unknown_iteration_count = True
         slothy.config.inputs_are_outputs = True
+        current_reserved = slothy.config.reserved_regs.copy()
+        current_reserved.add("r2")
+        slothy.config.reserved_regs = current_reserved
         slothy.optimize_loop("start")
 
 

--- a/tests/naive/armv7m/test_unknown_iter.s
+++ b/tests/naive/armv7m/test_unknown_iter.s
@@ -1,0 +1,14 @@
+.syntax unified
+
+count .req r2
+
+// Simple loop for testing unknown iteration count with non-power-of-2 unrolling on ARM v7m
+// This should trigger tail section generation when unroll > 1
+start:
+    add r5, r5, r4
+    add r7, r5, r1
+    ldr r5, [r0, #8]
+    add r5, r5, r7
+
+    subs count, count, #1
+    bgt start

--- a/tests/naive/armv7m/test_unknown_iter_pow2.s
+++ b/tests/naive/armv7m/test_unknown_iter_pow2.s
@@ -1,0 +1,14 @@
+.syntax unified
+
+count .req r2
+
+// Simple loop for testing unknown iteration count with power-of-2 unrolling on ARM v7m
+// This should trigger tail section generation when unroll > 1
+start:
+    add r5, r5, r4
+    add r7, r5, r1
+    ldr r5, [r0, #8]
+    add r5, r5, r7
+
+    subs count, count, #1
+    bgt start


### PR DESCRIPTION
- Resolves https://github.com/slothy-optimizer/slothy/issues/286

Disclaimer: This was primarily written by Claude Code with some help from Amazon Q. I have done quite a few iterations, but still care should be taken verifying the changes made.

- Add Branch class methods for handling division and remainder operations
  - Power-of-2: Use LSR/AND instructions
  - Non-power-of-2: Use UDIV/MLS instructions with temporary registers

- Add test cases for both power-of-2 (unroll=4) and non-power-of-2 (unroll=3)
  - AArch64: aarch64_unknown_iter{,_pow2}.s
  - ARMv7-M: test_unknown_iter{,_pow2}.s

- Update loop classes to handle arbitrary unroll factors
  - Remove power-of-2 assertions
  - Add temp_reg_for_division parameter
  - Use Branch.divide_by_constant for division