### PR TITLE
Feat: Supporting immediate values without #

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -874,7 +874,11 @@ class AArch64Instruction(Instruction):
 
         flag_pattern = "|".join(flaglist)
         dt_pattern = "(?:|2|4|8|16)(?:B|H|S|D|b|h|s|d)"
-        imm_pattern = "#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|,)+"
+        imm_pattern = (
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "|"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+        )
         index_pattern = "[0-9]+"
 
         src = replace_placeholders(src, "imm", imm_pattern, "imm")
@@ -1046,7 +1050,9 @@ class AArch64Instruction(Instruction):
                 )
 
         group_to_attribute("datatype", "datatype", lambda x: x.lower())
-        group_to_attribute("imm", "immediate", lambda x: x[1:])  # Strip '#'
+        group_to_attribute(
+            "imm", "immediate", lambda x: x.replace("#", "")
+        )  # Strip '#'
         group_to_attribute("index", "index", int)
         group_to_attribute("flag", "flag")
 

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -1079,7 +1079,11 @@ class Armv7mInstruction(Instruction):
         flag_pattern = "|".join(flaglist)
         # TODO: Notion of dt can be placed with notion for size in FP instructions
         dt_pattern = "(?:|2|4|8|16)(?:B|H|S|D|b|h|s|d)"
-        imm_pattern = "#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|,)+"
+        imm_pattern = (
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "|"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+        )
         index_pattern = "[0-9]+"
         width_pattern = r"(?:\.w|\.n|)"
         barrel_pattern = "(?:lsl|ror|lsr|asr)\\\\s*"
@@ -1292,7 +1296,9 @@ class Armv7mInstruction(Instruction):
                 )
 
         group_to_attribute("datatype", "datatype", lambda x: x.lower())
-        group_to_attribute("imm", "immediate", lambda x: x[1:])  # Strip '#'
+        group_to_attribute(
+            "imm", "immediate", lambda x: x.replace("#", "")
+        )  # Strip '#'
         group_to_attribute("index", "index", int)
         group_to_attribute("flag", "flag")
         group_to_attribute("width", "width")

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -619,7 +619,11 @@ class MVEInstruction(Instruction):
 
         dt_pattern = "(?:|u|s|i|U|S|I)(?:8|16|32|64)"
         fdt_pattern = "(?:|f|F)(?:16|32)"
-        imm_pattern = "#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|,)+"
+        imm_pattern = (
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "|"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+        )
         index_pattern = "[0-9]+"
         src = replace_placeholders(src, "imm", imm_pattern, "imm")
         src = replace_placeholders(src, "dt", dt_pattern, "datatype")
@@ -783,7 +787,9 @@ class MVEInstruction(Instruction):
                 )
 
         group_to_attribute("datatype", "datatype", lambda x: x.lower())
-        group_to_attribute("imm", "immediate", lambda x: x[1:])  # Strip '#'
+        group_to_attribute(
+            "imm", "immediate", lambda x: x.replace("#", "")
+        )  # Strip '#'
         group_to_attribute("index", "index", int)
 
         for s, ty in obj.pattern_inputs:

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -1,6 +1,10 @@
 start:
 
 // TODO: this is currently incomplete. We should add all instructions
+
+add x2, x1, #64
+add x2, x1, 64
+
 shl v0.16b, v1.16b, #4
 shl d2, d3, #8
 sshr v4.16b, v5.16b, #2
@@ -13,7 +17,11 @@ uzp1 v11.16b, v12.16b, v13.16b
 uzp2 v14.16b, v15.16b, v16.16b
 and v16.16b, v17.16b, v18.16b
 bic v19.16b, v20.16b, v21.16b
+bic v0.8h, #0xf0, lsl 8
 bic v0.8h, #0xf0, lsl #8
+bic v0.8h, 0xf0, lsl 8
+bic v0.8h, 0xf0, lsl #8
+
 mvn v22.16b, v23.16b
 orr v24.16b, v25.16b, v26.16b
 orn v27.16b, v28.16b, v29.16b
@@ -29,6 +37,7 @@ aesmc v2.16b, v3.16b
 sub  x2, x2, #48
 cmlt v4.8h, v30.8h, #0
 cmle v4.8h, v30.8h, #0
+cmle v4.8h, v30.8h, 0
 cmhs v4.8h, v30.8h, v16.8h
 cmgt v4.8h, v30.8h, v16.8h
 cmeq v4.8h, v30.8h, v16.8h

--- a/tests/naive/armv8m/instructions.s
+++ b/tests/naive/armv8m/instructions.s
@@ -8,6 +8,9 @@ sub r0, r1, r2
 ldr r0, [sp, #4]
 ldr r1, [r13, #8]
 
+ldr r0, [sp, #4]
+ldr r1, [r13, 8]
+
 vmulh.u8 q2, q0, q1
 vmulh.u16 q2, q0, q1
 vmulh.u32 q2, q0, q1
@@ -79,6 +82,13 @@ strd r0, r1, [r2], #16
 strd r0, r1, [r2], #-16
 strd r0, r1, [r2, #16]!
 strd r0, r1, [r2, #-16]!
+
+strd r0, r1, [r2, 16]
+strd r0, r1, [r2, -16]
+strd r0, r1, [r2], 16
+strd r0, r1, [r2], -16
+strd r0, r1, [r2, 16]!
+strd r0, r1, [r2, -16]!
 
 vrshr.u8 q2, q0, #8
 vrshr.u16 q2, q0, #16
@@ -263,11 +273,20 @@ vstrw.32 q0, [r0, #16]
 vstrw.32 q0, [r0], #16
 vstrw.32 q0, [r0, #16]!
 
+vstrw.u32 Q0, [r1, Q2, UXTW #2]
+vstrw.u32 Q0, [r1, Q2, UXTW 2]
+
 vldrb.u8 q0, [r0, #16]
 vldrb.u8 q0, [r0], #16
 vldrb.u8 q0, [r0, #16]!
 vldrb.u16 q0, [r0, #16]
 vldrb.u32 q0, [r0, #16]
+
+vldrb.u8 q0, [r0, 16]
+vldrb.u8 q0, [r0], 16
+vldrb.u8 q0, [r0, 16]!
+vldrb.u16 q0, [r0, 16]
+vldrb.u32 q0, [r0, 16]
 
 vldrh.u32 q0, [r0, #16]
 vldrh.u32 q0, [r0], #16
@@ -342,6 +361,11 @@ vcmul.f16 q2, q0, q1, #90
 vcmul.f16 q2, q0, q1, #180 
 vcmul.f16 q2, q0, q1, #270 
 
+vcmul.f16 q2, q0, q1, 0 
+vcmul.f16 q2, q0, q1, 90 
+vcmul.f16 q2, q0, q1, 180 
+vcmul.f16 q2, q0, q1, 270 
+
 vcmul.f32 q2, q0, q1, #0 
 vcmul.f32 q2, q0, q1, #90 
 vcmul.f32 q2, q0, q1, #180 
@@ -361,6 +385,5 @@ vhcadd.s16 q2, q0, q1, #270
 vhcadd.s32 q2, q0, q1, #90
 vhcadd.s32 q2, q0, q1, #270
 
-vstrw.u32 Q0, [r1, Q2, UXTW #2]
 
 end:


### PR DESCRIPTION
- Resolves #284 
- This commit suppoting immediate values without `#`
- Following model are supported:
  - `aarch64`
  - `arch_v7m`
  - `arch_v81m`
1. The `imm_pattern` was updated to recognize immediate values regardless of the presence of `#`, and the `<imm>` prefix strip off logic was adjusted accordingly.
2. Additionally, commas `,` were removed from `imm_pattern` to avoid misinterpreting operands like `q2, UXTW 2` as a single immediate:
```
.syntax unified
start:
vstrw.32 q0, [r0, #16]
vstrw.u32 q0, [r0, q2, UXTW 2].
end:
```
3. To support symbolic aliases like `#(SHIFT)`, used in instructions such as follow, we now combine the old symbolic-style and the new numeric literal patterns. This allows both formats to be parsed properly.
```
vrshr.s32 q0, q1, #(SHIFT)
```
