### PR TITLE
Remove simple arithmetic wrapper macros from AArch64 assembly files

### DIFF
--- a/examples/naive/aarch64/dilithium/intt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/dilithium/intt_dilithium_1234_5678.s
@@ -47,21 +47,6 @@
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vsub d,a,b
-        sub \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vadd d,a,b
-        add \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmul d,a,b
-        mul \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -71,52 +56,40 @@
 .macro vmlsq d,a,b,i
         mls \d\().4s, \a\().4s, \b\().s[\i]
 .endm
-.macro trn1_d d,a,b
-        trn1 \d\().2d, \a\().2d, \b\().2d
-.endm
-.macro trn2_d d,a,b
-        trn2 \d\().2d, \a\().2d, \b\().2d
-.endm
-.macro trn1_s d,a,b
-        trn1 \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro trn2_s d,a,b
-        trn2 \d\().4s, \a\().4s, \b\().4s
-.endm
 
 .macro mulmodq dst, src, const, idx0, idx1
         vqrdmulhq   t2,  \src, \const, \idx1
         vmulq       \dst,  \src, \const, \idx0
-        vmls       \dst,  t2, modulus
+        mls \dst.4s,  t2.4s, modulus.4s
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
-        vmls       \dst,  t2, modulus
+        mls \dst.4s,  t2.4s, modulus.4s
 .endm
 
 .macro barrett_reduce_single a
         srshr tmp.4S,  \a\().4S, #23
-        vmls   \a, tmp, modulus
+        mls \a.4s, tmp.4s, modulus.4s
 .endm
 
 .macro canonical_reduce a, modulus_half, neg_modulus_half, tmp1, tmp2
         cmge \tmp1\().4s, \neg_modulus_half\().4s, \a\().4s
         cmge \tmp2\().4s, \a\().4s, \modulus_half\().4s
         sub \tmp2\().4s, \tmp1\().4s, \tmp2\().4s
-        vmls \a, \tmp2, modulus
+        mls \a.4s, \tmp2.4s, modulus.4s
 .endm
 
 .macro gs_butterfly a, b, root, idx0, idx1
-        vsub     tmp,    \a, \b
-        vadd     \a,    \a, \b
+        sub tmp.4s,    \a.4s, \b.4s
+        add \a.4s,    \a.4s, \b.4s
         mulmodq  \b, tmp, \root, \idx0, \idx1
 .endm
 
 .macro gs_butterfly_v a, b, root, root_twisted
-        vsub    tmp,    \a, \b
-        vadd    \a,    \a, \b
+        sub tmp.4s,    \a.4s, \b.4s
+        add \a.4s,    \a.4s, \b.4s
         mulmod  \b, tmp, \root, \root_twisted
 .endm
 
@@ -160,15 +133,15 @@
 .endm
 
 .macro transpose4 data
-        trn1_s t0, \data\()0, \data\()1
-        trn2_s t1, \data\()0, \data\()1
-        trn1_s t2, \data\()2, \data\()3
-        trn2_s t3, \data\()2, \data\()3
+        trn1 t0.4s, \data\()0.4s, \data\()1.4s
+        trn2 t1.4s, \data\()0.4s, \data\()1.4s
+        trn1 t2.4s, \data\()2.4s, \data\()3.4s
+        trn2 t3.4s, \data\()2.4s, \data\()3.4s
 
-        trn2_d \data\()2, t0, t2
-        trn2_d \data\()3, t1, t3
-        trn1_d \data\()0, t0, t2
-        trn1_d \data\()1, t1, t3
+        trn2 \data\()2.2d, t0.2d, t2.2d
+        trn2 \data\()3.2d, t1.2d, t3.2d
+        trn1 \data\()0.2d, t0.2d, t2.2d
+        trn1 \data\()1.2d, t1.2d, t3.2d
 .endm
 
 .macro save_gprs // @slothy:no-unfold

--- a/examples/naive/aarch64/dilithium/intt_dilithium_1234_5678_manual_ld4.s
+++ b/examples/naive/aarch64/dilithium/intt_dilithium_1234_5678_manual_ld4.s
@@ -47,21 +47,6 @@
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vsub d,a,b
-        sub \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vadd d,a,b
-        add \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmul d,a,b
-        mul \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -71,52 +56,40 @@
 .macro vmlsq d,a,b,i
         mls \d\().4s, \a\().4s, \b\().s[\i]
 .endm
-.macro trn1_d d,a,b
-        trn1 \d\().2d, \a\().2d, \b\().2d
-.endm
-.macro trn2_d d,a,b
-        trn2 \d\().2d, \a\().2d, \b\().2d
-.endm
-.macro trn1_s d,a,b
-        trn1 \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro trn2_s d,a,b
-        trn2 \d\().4s, \a\().4s, \b\().4s
-.endm
 
 .macro mulmodq dst, src, const, idx0, idx1
         vqrdmulhq   t2,  \src, \const, \idx1
         vmulq       \dst,  \src, \const, \idx0
-        vmls       \dst,  t2, modulus
+        mls \dst.4s,  t2.4s, modulus.4s
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
-        vmls       \dst,  t2, modulus
+        mls \dst.4s,  t2.4s, modulus.4s
 .endm
 
 .macro barrett_reduce_single a
         srshr tmp.4S,  \a\().4S, #23
-        vmls   \a, tmp, modulus
+        mls \a\().4s, tmp.4s, modulus.4s
 .endm
 
 .macro canonical_reduce a, modulus_half, neg_modulus_half, tmp1, tmp2
         cmge \tmp1\().4s, \neg_modulus_half\().4s, \a\().4s
         cmge \tmp2\().4s, \a\().4s, \modulus_half\().4s
         sub \tmp2\().4s, \tmp1\().4s, \tmp2\().4s
-        vmls \a, \tmp2, modulus
+        mls \a\().4s, \tmp2\().4s, modulus.4s
 .endm
 
 .macro gs_butterfly a, b, root, idx0, idx1
-        vsub     tmp,    \a, \b
-        vadd     \a,    \a, \b
+        sub tmp.4s, \a\().4s, \b\().4s
+        add \a\().4s, \a\().4s, \b\().4s
         mulmodq  \b, tmp, \root, \idx0, \idx1
 .endm
 
 .macro gs_butterfly_v a, b, root, root_twisted
-        vsub    tmp,    \a, \b
-        vadd    \a,    \a, \b
+        sub tmp.4s, \a\().4s, \b\().4s
+        add \a\().4s, \a\().4s, \b\().4s
         mulmod  \b, tmp, \root, \root_twisted
 .endm
 
@@ -160,15 +133,15 @@
 .endm
 
 .macro transpose4 data
-        trn1_s t0, \data\()0, \data\()1
-        trn2_s t1, \data\()0, \data\()1
-        trn1_s t2, \data\()2, \data\()3
-        trn2_s t3, \data\()2, \data\()3
+        trn1 t0.4s, \data\()0.4s, \data\()1.4s
+        trn2 t1.4s, \data\()0.4s, \data\()1.4s
+        trn1 t2.4s, \data\()2.4s, \data\()3.4s
+        trn2 t3.4s, \data\()2.4s, \data\()3.4s
 
-        trn2_d \data\()2, t0, t2
-        trn2_d \data\()3, t1, t3
-        trn1_d \data\()0, t0, t2
-        trn1_d \data\()1, t1, t3
+        trn2 \data\()2.2d, t0.2d, t2.2d
+        trn2 \data\()3.2d, t1.2d, t3.2d
+        trn1 \data\()0.2d, t0.2d, t2.2d
+        trn1 \data\()1.2d, t1.2d, t3.2d
 .endm
 
 .macro save_gprs // @slothy:no-unfold

--- a/examples/naive/aarch64/dilithium/intt_dilithium_123_45678.s
+++ b/examples/naive/aarch64/dilithium/intt_dilithium_123_45678.s
@@ -27,12 +27,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -53,21 +47,21 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm
 
 .macro barrett_reduce_single a
         srshr tmp.4S,  \a\().4S, #23
-        vmls   \a, tmp, consts
+        mls \a.4s, tmp.4s, consts.4s
 .endm
 
 .macro canonical_reduce a, modulus_half, neg_modulus_half, tmp1, tmp2
         cmge \tmp1\().4s, \neg_modulus_half\().4s, \a\().4s
         cmge \tmp2\().4s, \a\().4s, \modulus_half\().4s
         sub \tmp2\().4s, \tmp1\().4s, \tmp2\().4s
-        vmls \a, \tmp2, consts
+        mls \a.4s, \tmp2.4s, consts.4s
 .endm
 
 .macro gs_butterfly a, b, root, idx0, idx1

--- a/examples/naive/aarch64/dilithium/intt_dilithium_123_45678_manual_ld4.s
+++ b/examples/naive/aarch64/dilithium/intt_dilithium_123_45678_manual_ld4.s
@@ -27,12 +27,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -53,21 +47,21 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm
 
 .macro barrett_reduce_single a
         srshr tmp.4S,  \a\().4S, #23
-        vmls   \a, tmp, consts
+        mls \a.4s, tmp.4s, consts.4s
 .endm
 
 .macro canonical_reduce a, modulus_half, neg_modulus_half, tmp1, tmp2
         cmge \tmp1\().4s, \neg_modulus_half\().4s, \a\().4s
         cmge \tmp2\().4s, \a\().4s, \modulus_half\().4s
         sub \tmp2\().4s, \tmp1\().4s, \tmp2\().4s
-        vmls \a, \tmp2, consts
+        mls \a.4s, \tmp2.4s, consts.4s
 .endm
 
 .macro gs_butterfly a, b, root, idx0, idx1

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_1234_5678.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_1234_5678.s
@@ -47,9 +47,6 @@
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vmla d,a,b
         mla \d\().4s, \a\().4s, \b\().4s
 .endm
@@ -74,7 +71,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmla       \dst,  t2, modulus
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_1234_5678_manual_st4.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_1234_5678_manual_st4.s
@@ -47,9 +47,6 @@
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vmla d,a,b
         mla \d\().4s, \a\().4s, \b\().4s
 .endm
@@ -73,7 +70,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmla       \dst,  t2, modulus
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678.s
@@ -27,12 +27,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -53,7 +47,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_manual_st4.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_manual_st4.s
@@ -27,12 +27,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -53,7 +47,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_red.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_red.s
@@ -28,12 +28,6 @@
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -54,7 +48,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_w_scalar.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_w_scalar.s
@@ -37,12 +37,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -63,7 +57,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_w_scalar_red.s
+++ b/examples/naive/aarch64/dilithium/ntt_dilithium_123_45678_w_scalar_red.s
@@ -33,12 +33,6 @@ xtmp1 .req x11
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
 .endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro vmls d,a,b
-        mls \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro vqrdmulhq d,a,b,i
         sqrdmulh \d\().4s, \a\().4s, \b\().s[\i]
 .endm
@@ -59,7 +53,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.4s,  \src.4s, \const_twisted.4s
         mul        \dst\().4s,  \src\().4s, \const\().4s
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/kyber/intt_kyber_123_4567_manual_ld4.s
+++ b/examples/naive/aarch64/kyber/intt_kyber_123_4567_manual_ld4.s
@@ -50,9 +50,6 @@
         str qform_\vec, [\base], #\inc
 .endm
 
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
-.endm
 .macro vmlsq d,a,b,i
         mls \d\().8h, \a\().8h, \b\().h[\i]
 .endm
@@ -73,7 +70,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/kyber/ntt_kyber_1234_567.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_1234_567.s
@@ -35,12 +35,6 @@
 // Eventually, NeLight should include a proper parser for AArch64,
 // but for initial investigations, the below is enough.
 
-.macro trn1_s d,a,b
-        trn1 \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro trn2_s d,a,b
-        trn2 \d\().4s, \a\().4s, \b\().4s
-.endm
 .macro ldr_vo vec, base, offset
         ldr qform_\vec, [\base, #\offset]
 .endm
@@ -52,9 +46,6 @@
 .endm
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
-.endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
 .endm
 .macro vmla d,a,b
         mla \d\().8h, \a\().8h, \b\().8h
@@ -79,7 +70,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlaq       \dst,  t2, consts, 0
 .endm
@@ -436,14 +427,14 @@ layer567_start:
         ld4 {data8.4S, data9.4S, data10.4S, data11.4S}, [src0]
         ld4 {data12.4S, data13.4S, data14.4S, data15.4S}, [src1]
 
-        trn1_s data0, data8, data12
-        trn2_s data4, data8, data12
-        trn1_s data1, data9, data13
-        trn2_s data5, data9, data13
-        trn1_s data2, data10, data14
-        trn2_s data6, data10, data14
-        trn1_s data3, data11, data15
-        trn2_s data7, data11, data15
+        trn1 data0.4s, data8.4s, data12.4s
+        trn2 data4.4s, data8.4s, data12.4s
+        trn1 data1.4s, data9.4s, data13.4s
+        trn2 data5.4s, data9.4s, data13.4s
+        trn1 data2.4s, data10.4s, data14.4s
+        trn2 data6.4s, data10.4s, data14.4s
+        trn1 data3.4s, data11.4s, data15.4s
+        trn2 data7.4s, data11.4s, data15.4s
 
         // load twiddle factors
         ldr_vi root0,    r_ptr1, 16*14
@@ -489,14 +480,14 @@ layer567_start:
         barrett_reduce data7
 
         // transpose back
-        trn1_s  data8, data0, data4
-        trn2_s data12, data0, data4
-        trn1_s  data9, data1, data5
-        trn2_s data13, data1, data5
-        trn1_s data10, data2, data6
-        trn2_s data14, data2, data6
-        trn1_s data11, data3, data7
-        trn2_s data15, data3, data7
+        trn1 data8.4s, data0.4s, data4.4s
+        trn2 data12.4s, data0.4s, data4.4s
+        trn1 data9.4s, data1.4s, data5.4s
+        trn2 data13.4s, data1.4s, data5.4s
+        trn1 data10.4s, data2.4s, data6.4s
+        trn2 data14.4s, data2.4s, data6.4s
+        trn1 data11.4s, data3.4s, data7.4s
+        trn2 data15.4s, data3.4s, data7.4s
 
         st4 {data8.4S, data9.4S, data10.4S, data11.4S}, [src0], #64
         st4 {data12.4S, data13.4S, data14.4S, data15.4S}, [src1], #64

--- a/examples/naive/aarch64/kyber/ntt_kyber_1234_567_manual_st4.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_1234_567_manual_st4.s
@@ -35,12 +35,6 @@
 // Eventually, NeLight should include a proper parser for AArch64,
 // but for initial investigations, the below is enough.
 
-.macro trn1_s d,a,b
-        trn1 \d\().4s, \a\().4s, \b\().4s
-.endm
-.macro trn2_s d,a,b
-        trn2 \d\().4s, \a\().4s, \b\().4s
-.endm
 
 .macro ldr_vo vec, base, offset
         ldr qform_\vec, [\base, #\offset]
@@ -53,9 +47,6 @@
 .endm
 .macro str_vi vec, base, inc
         str qform_\vec, [\base], #\inc
-.endm
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
 .endm
 .macro vmla d,a,b
         mla \d\().8h, \a\().8h, \b\().8h
@@ -80,7 +71,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlaq       \dst,  t2, consts, 0
 .endm
@@ -444,14 +435,14 @@ layer567_start:
         ld4 {data8.4S, data9.4S, data10.4S, data11.4S}, [src0]
         ld4 {data12.4S, data13.4S, data14.4S, data15.4S}, [src1]
 
-        trn1_s data0, data8, data12
-        trn2_s data4, data8, data12
-        trn1_s data1, data9, data13
-        trn2_s data5, data9, data13
-        trn1_s data2, data10, data14
-        trn2_s data6, data10, data14
-        trn1_s data3, data11, data15
-        trn2_s data7, data11, data15
+        trn1 data0.4s, data8.4s, data12.4s
+        trn2 data4.4s, data8.4s, data12.4s
+        trn1 data1.4s, data9.4s, data13.4s
+        trn2 data5.4s, data9.4s, data13.4s
+        trn1 data2.4s, data10.4s, data14.4s
+        trn2 data6.4s, data10.4s, data14.4s
+        trn1 data3.4s, data11.4s, data15.4s
+        trn2 data7.4s, data11.4s, data15.4s
 
         // load twiddle factors
         ldr_vi root0,    r_ptr1, 16*14
@@ -497,14 +488,14 @@ layer567_start:
         barrett_reduce data7
 
         // transpose back
-        trn1_s  data8, data0, data4
-        trn2_s data12, data0, data4
-        trn1_s  data9, data1, data5
-        trn2_s data13, data1, data5
-        trn1_s data10, data2, data6
-        trn2_s data14, data2, data6
-        trn1_s data11, data3, data7
-        trn2_s data15, data3, data7
+        trn1 data8.4s, data0.4s, data4.4s
+        trn2 data12.4s, data0.4s, data4.4s
+        trn1 data9.4s, data1.4s, data5.4s
+        trn2 data13.4s, data1.4s, data5.4s
+        trn1 data10.4s, data2.4s, data6.4s
+        trn2 data14.4s, data2.4s, data6.4s
+        trn1 data11.4s, data3.4s, data7.4s
+        trn2 data15.4s, data3.4s, data7.4s
 
         // manual_st4
         transpose4 data8, data9, data10, data11

--- a/examples/naive/aarch64/kyber/ntt_kyber_123_4567_manual_st4.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_123_4567_manual_st4.s
@@ -50,9 +50,6 @@
         str qform_\vec, [\base], #\inc
 .endm
 
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
-.endm
 .macro vmlsq d,a,b,i
         mls \d\().8h, \a\().8h, \b\().h[\i]
 .endm
@@ -73,7 +70,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_load.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_load.s
@@ -62,9 +62,6 @@ xtmp1 .req x11
         str qform_\vec, [\base], #\inc
 .endm
 
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
-.endm
 .macro vmlsq d,a,b,i
         mls \d\().8h, \a\().8h, \b\().h[\i]
 .endm
@@ -85,7 +82,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_load_store.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_load_store.s
@@ -66,9 +66,6 @@ xtmp1 .req x11
         str qform_\vec, [\base], #\inc
 .endm
 
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
-.endm
 .macro vmlsq d,a,b,i
         mls \d\().8h, \a\().8h, \b\().h[\i]
 .endm
@@ -89,7 +86,7 @@ xtmp1 .req x11
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlsq      \dst,  t2, consts, 0
 .endm

--- a/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_store.s
+++ b/examples/naive/aarch64/kyber/ntt_kyber_123_4567_scalar_store.s
@@ -49,9 +49,6 @@
         str qform_\vec, [\base], #\inc
 .endm
 
-.macro vqrdmulh d,a,b
-        sqrdmulh \d\().8h, \a\().8h, \b\().8h
-.endm
 .macro vmlsq d,a,b,i
         mls \d\().8h, \a\().8h, \b\().h[\i]
 .endm
@@ -72,7 +69,7 @@
 .endm
 
 .macro mulmod dst, src, const, const_twisted
-        vqrdmulh   t2,  \src, \const_twisted
+        sqrdmulh t2.8h,  \src.8h, \const_twisted.8h
         mul        \dst\().8h,  \src\().8h, \const\().8h
         vmlsq      \dst,  t2, consts, 0
 .endm


### PR DESCRIPTION
Remove unnecessary wrapper macros for basic AArch64 NEON instructions and replace with native instruction calls. SLOTHY now has native support for these instructions, making the wrappers redundant.

Removed macros:
- vmls -> mls .4s/.8h
- vadd -> add .4s/.8h
- vsub -> sub .4s/.8h
- vmul -> mul .4s/.8h
- vqrdmulh -> sqrdmulh .4s/.8h
- trn1_d -> trn1 .2d
- trn2_d -> trn2 .2d
- trn1_s -> trn1 .4s
- trn2_s -> trn2 .4s

Fixes #59

Still need to run the re-optimization for those. 