### PR TITLE
Don't use str(line)

### DIFF
--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -193,7 +193,7 @@ class Slothy:
         fun = logger.debug if not err else logger.error
         fun(f"Dump: {name}")
         for line in s:
-            fun(f"> {line}")
+            fun(f"> {line.to_string()}")
 
     def global_selftest(
         self, funcname: str, address_registers: any, iterations: int = 5


### PR DESCRIPTION
In `helper.py`, an `AsmHelperException` is raised if `__str__()` is called on a `SourceLine` object. I found (at least) this one case, where the optimization of a WIP example failed due to a `SourceLine` being used inside an f-string. Fixed by using `to_string()` from `SourceLine`.