### PR TITLE
Switch default logging to stdout; default log level INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,9 @@ pip install slothy
 Here's a minimal example of using SLOTHY to optimize assembly code:
 
 ```python
-import sys
-import logging 
-
 import slothy
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 # Create SLOTHY instance for ARM Cortex-A55
 s = slothy.Slothy(AArch64_Neon, Target_CortexA55)

--- a/docs/source/tutorial/README.md
+++ b/docs/source/tutorial/README.md
@@ -265,15 +265,10 @@ When writing your own calls to SLOTHY, there are generally two options:
 To reproduce the example above, you can place the following code into your own Python script in the root directory of SLOTHY:
 
 ```python
-import logging
-import sys
-
 from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -48,6 +48,7 @@ one-shot and heuristic optimizations using SLOTHY.
 """
 
 import logging
+import sys
 from types import SimpleNamespace
 
 from slothy.core.dataflow import DataFlowGraph as DFG
@@ -97,7 +98,15 @@ class Slothy:
 
     def __init__(self, arch, target, logger=None):
         self.config = Config(arch, target)
-        self.logger = logger if logger is not None else logging.getLogger("slothy")
+
+        # Configure default logging to stdout if no handlers are configured
+        if logger is None:
+            root_logger = logging.getLogger()
+            if not root_logger.handlers:
+                logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+            self.logger = logging.getLogger("slothy")
+        else:
+            self.logger = logger
 
         # The source, once loaded, is represented as a list of strings
         self._source = None

--- a/tutorial/tutorial-3a.py
+++ b/tutorial/tutorial-3a.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/tutorial/tutorial-3b.py
+++ b/tutorial/tutorial-3b.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/tutorial/tutorial-4.py
+++ b/tutorial/tutorial-4.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/tutorial/tutorial-5.py
+++ b/tutorial/tutorial-5.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/tutorial/tutorial-6.py
+++ b/tutorial/tutorial-6.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55

--- a/tutorial/tutorial-7.py
+++ b/tutorial/tutorial-7.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 if __name__ == "__main__":
@@ -8,8 +7,6 @@ from slothy import Slothy
 
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 arch = AArch64_Neon
 target = Target_CortexA55


### PR DESCRIPTION
Before, SLOTHY would not log anything by default leaving it up to the user to configure logging.
This is tedious and confusing.
This commit changes: If no loggers are configured, it defaults to logging to stdout with log level INFO.
The README and the tutorial are adjusted accoringly.

Resolves https://github.com/slothy-optimizer/slothy/issues/294