### PR TITLE
Fix: Do not create model dir if log_model is not set

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -31,7 +31,6 @@ SLOTHY configuration
 
 
 from copy import deepcopy
-import os
 
 from slothy.helper import LockAttributes, NestedPrint
 
@@ -1391,8 +1390,6 @@ class Config(NestedPrint, LockAttributes):
 
         self.log_model_log_results = True
         self.log_model_results_file = "results.txt"
-        if not os.path.exists(self.log_model_dir):
-            os.makedirs(self.log_model_dir)
 
         self.lock()
 

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -27,6 +27,7 @@
 
 import logging
 import math
+import os
 import time
 
 from types import SimpleNamespace
@@ -4045,6 +4046,10 @@ class SlothyBase(LockAttributes):
     def _export_model(self):
         if self.config.log_model is None:
             return
+
+        # Create log_model_dir if it doesn't exist
+        if not os.path.exists(self.config.log_model_dir):
+            os.makedirs(self.config.log_model_dir)
 
         if self.config.log_model is True:
             model_file = "slothy_model"


### PR DESCRIPTION
Resolves https://github.com/slothy-optimizer/slothy/issues/296