### PR TITLE
protobuf: Pin the version below 6.31.1(ortools 9.7 requires protobuf <= 6.31.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,11 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ortools==9.7.2996; python_version < '3.13'",
+    # ortools depends on pandas, but 9.7 does not specify it as dependency
+    "pandas>=2.0.3; python_version < '3.13'",
+    # ortools 9.7 requires protobuf<=6.31.1
+    "protobuf<=6.31.1 ; python_version < '3.13'",
     "ortools==9.12.4544; python_version >= '3.13'",
-    "pandas>=2.0.3",
     "sympy==1.14.0",
     "unicorn==2.1.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 ortools==9.7.2996 ; python_version < "3.13"
 ortools==9.12.4544 ; python_version >= "3.13"
-# TODO: remove pandas once upgraded to ortools 9.12
-pandas>=2.0.3
+# ortools 9.7 requires protobuf<=6.31.1
+protobuf<=6.31.1 ; python_version < "3.13"
+# ortools depends on pandas, but 9.7 does not specify it as dependency
+pandas>=2.0.3 ; python_version < "3.13"
 sympy==1.14.0
 unicorn==2.1.3
 black


### PR DESCRIPTION
This PR fixes the CI dependency error related to the `protobuf` version by:
- We fixed this error by pinning protobuf to the original working version(`ortools 9.7 requires protobuf <= 6.31.1`).

- We found that ortools `9.7.2996` recently automatically updates protobuf from `6.31.1` to `6.32.0`, this will causes errors in `AddHint()` in ortools, so we pin the protobuf version under 6.31.1 to solve this problem.

ref: 
- protobuf v32.0 release note: https://github.com/protocolbuffers/protobuf/releases/tag/v32.0