### PR TITLE
Fix: correct the warning message phrased for // @slothy:ignore_useless_output

### DIFF
--- a/slothy/core/dataflow.py
+++ b/slothy/core/dataflow.py
@@ -772,9 +772,15 @@ class DataFlowGraph:
                 f"of instruction {t.id}:[{t.inst}] are neither used "
                 "nor declared as global outputs."
             )
-            self.logger.warning(
-                "Ignoring this as requested by `config.allow_useless_instructions`!"
-            )
+            if ignore_useless_output:
+                self.logger.warning(
+                    "Ignoring this as requested by "
+                    "`// @slothy:ignore_useless_output` annotation!"
+                )
+            else:
+                self.logger.warning(
+                    "Ignoring this as requested by `config.allow_useless_instructions`!"
+                )
 
     def _parse_line(self, line):
         assert SourceLine.is_source_line(line)

--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -103,6 +103,19 @@ class HintTest(OptimizationRunner):
         slothy.optimize()
 
 
+class TagTest(OptimizationRunner):
+    def __init__(self):
+        super().__init__(
+            "tag_test",
+            arch=Arch_Armv81M,
+            target=Target_CortexM55r1,
+            base_dir="tests",
+        )
+
+    def core(self, slothy):
+        slothy.optimize()
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexM85r1),
@@ -112,4 +125,5 @@ test_instances = [
     Example3(),
     LoopLe(),
     HintTest(),
+    TagTest(),
 ]

--- a/tests/naive/armv8m/tag_test.s
+++ b/tests/naive/armv8m/tag_test.s
@@ -1,0 +1,3 @@
+vstrw.u32  q0, [r0]
+vldrw.u32  q2, [r0]  // @slothy:ignore_useless_output
+


### PR DESCRIPTION
- Resolves: #305

- This PR fixes the warning message shown when using the `// @slothy:ignore_useless_output` annotation.
- Previously, the message incorrectly stated "Ignoring this as requested by \`config.allow_useless_instructions\`!" even when the `// @slothy:ignore_useless_output` annotation was used.
- It now correctly displays: "Ignoring this as requested by \`// @slothy:ignore_useless_output\` annotation!".