### PR TITLE
AArch64: Add eon instruction

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -2170,12 +2170,6 @@ class asr_wform(AArch64Instruction):
     outputs = ["Wd"]
 
 
-class eor_wform(AArch64Instruction):
-    pattern = "eor <Wd>, <Wa>, <Wb>"
-    inputs = ["Wa", "Wb"]
-    outputs = ["Wd"]
-
-
 class AArch64BasicArithmetic(AArch64Instruction):
     pass
 
@@ -2502,8 +2496,26 @@ class rev_w(AArch64Logical):
     outputs = ["Wd"]
 
 
+class eor_wform(AArch64Logical):
+    pattern = "eor <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class eon_wform(AArch64Logical):
+    pattern = "eon <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
 class eor(AArch64Logical):
     pattern = "eor <Xd>, <Xa>, <Xb>"
+    inputs = ["Xa", "Xb"]
+    outputs = ["Xd"]
+
+
+class eon(AArch64Logical):
+    pattern = "eon <Xd>, <Xa>, <Xb>"
     inputs = ["Xa", "Xb"]
     outputs = ["Xd"]
 

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -119,6 +119,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     bic,
     bic_reg,
     eor,
+    eon,
     ror,
     eor_shifted,
     bic_shifted,
@@ -149,6 +150,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     asr_wform,
     and_imm_wform,
     eor_wform,
+    eon_wform,
     lsr_wform,
     ASimdCompare,
     and_twoarg,
@@ -383,6 +385,7 @@ execution_units = {
         movw_imm,
         cmp_imm,
         eor,
+        eon,
         eor_shifted,
         bic_shifted,
         ror,
@@ -410,6 +413,7 @@ execution_units = {
         and_imm_wform,
         lsr_wform,
         eor_wform,
+        eon_wform,
     ): ExecutionUnit.SCALAR(),
     AArch64ConditionalCompare: ExecutionUnit.SCALAR(),
     # NOTE: AESE/AESMC and AESD/AESIMC pairs can be dual-issued on A55 but this
@@ -489,8 +493,8 @@ inverse_throughput = {
     (b_ldr_stack_with_inc, d_ldr_stack_with_inc): 1,
     (mov_d01, mov_b00): 1,
     (vzip1, vzip2): 1,
-    (eor_wform): 1,
-    (eor, bic, bic_reg, eor_shifted, bic_shifted): 1,
+    (eor_wform, eon_wform): 1,
+    (eon, eor, bic, bic_reg, eor_shifted, bic_shifted): 1,
     AArch64ConditionalCompare: 1,
     AESInstruction: 1,
     fmov_s_form: 1,  # from double/single to gen reg
@@ -565,12 +569,12 @@ default_latencies = {
     (b_ldr_stack_with_inc, d_ldr_stack_with_inc): 3,
     (mov_d01, mov_b00): 2,
     (vzip1, vzip2): 2,
-    (eor_wform): 1,
+    (eor_wform, eon_wform): 1,
     # According to SWOG, this is 2 cycles, byt if the output is used as a
     # _non-shifted_ input to the next instruction, the effective latency
     # seems to be 1 cycle. See https://eprint.iacr.org/2022/1243.pdf
     (eor_shifted, bic_shifted): 1,
-    (ror, eor, bic, bic_reg): 1,
+    (eon, ror, eor, bic, bic_reg): 1,
     AArch64ConditionalCompare: 1,
     # NOTE: AESE/AESMC and AESD/AESIMC pairs can be dual-issued on A55 but this
     # is not modeled

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -59,6 +59,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     find_class,
     all_subclass_leaves,
     AArch64ConditionalCompare,
+    AArch64Logical,
     Ldr_X,
     Str_X,
     Ldr_Q,
@@ -93,7 +94,6 @@ from slothy.targets.aarch64.aarch64_neon import (
     St2,
     Ld3,
     Ld4,
-    ubfx,
     AESInstruction,
     vext,
     AArch64NeonCount,
@@ -203,6 +203,7 @@ execution_units = {
     ],
     AArch64NeonShiftInsert: [ExecutionUnit.ASIMD1],
     AArch64ConditionalCompare: ExecutionUnit.INT(),
+    AArch64Logical: [ExecutionUnit.INT()],
     # 8B/8H occupies both F0, F1
     vuaddlv_sform: [[ExecutionUnit.ASIMD0, ExecutionUnit.ASIMD1]],
     Vins: [ExecutionUnit.ASIMD0, ExecutionUnit.ASIMD1],
@@ -210,7 +211,7 @@ execution_units = {
     (Ldr_Q, Ldr_X): ExecutionUnit.LOAD(),
     (Str_Q, Str_X): ExecutionUnit.STORE(),
     AArch64Move: ExecutionUnit.SCALAR(),
-    (add, add_imm, add_shifted, ubfx): ExecutionUnit.SCALAR(),
+    (add, add_imm, add_shifted): ExecutionUnit.SCALAR(),
     (VShiftImmediateRounding, VShiftImmediateBasic): [ExecutionUnit.ASIMD1],
     (St4, St3, St2): [ExecutionUnit.ASIMD0, ExecutionUnit.ASIMD1],
     (Ld3, Ld4): [
@@ -244,6 +245,7 @@ inverse_throughput = {
     AArch64NeonLogical: 1,
     AArch64NeonShiftInsert: 1,
     AArch64ConditionalCompare: 1,
+    AArch64Logical: 1,
     Vins: 1,
     umov_d: 1,
     (add, add_imm, add_shifted): 1,
@@ -255,7 +257,6 @@ inverse_throughput = {
     St4: 8,
     Ld3: 3,
     Ld4: 4,
-    ubfx: 1,
     vtbl: 1,  # SWOG contains a blank throughput (approximating from AArch32)
     AESInstruction: 1,
     sub_imm: 1,
@@ -292,6 +293,7 @@ default_latencies = {
     AArch64NeonLogical: 3,
     AArch64NeonShiftInsert: 3,
     AArch64ConditionalCompare: 1,
+    AArch64Logical: 1,
     (Ldr_Q, Ldr_X, Str_Q, Str_X): 4,  # approx
     Vins: 6,  # approx
     umov_d: 4,  # approx
@@ -305,7 +307,6 @@ default_latencies = {
     St4: 8,
     Ld3: 3,
     Ld4: 4,
-    ubfx: 1,
     vtbl: 6,  # q-form: 3*N+3 cycles (N = number of registers in the table)
     AESInstruction: 3,
     sub_imm: 3,

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -5,6 +5,9 @@ start:
 add x2, x1, #64
 add x2, x1, 64
 
+eon x2, x2, x1
+eon w2, w2, w1
+
 shl v0.16b, v1.16b, #4
 shl d2, d3, #8
 sshr v4.16b, v5.16b, #2


### PR DESCRIPTION
this pr adds the `eon` instruction to `aarch64` architecture and to the `a55`, `a72`, `neoverse N1` micro architectures. 
Note for `a72` I import the superset `AArch64Logical` instead of just `eon`, which includes all other logical instructions. And for N1 nothing had to be done, as it already imports `AArch64Logical`. 

