### PR TITLE
Use ortools 9.12 for Python 3.12 and newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,12 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "ortools==9.7.2996; python_version < '3.13'",
+    "ortools==9.7.2996; python_version < '3.12'",
     # ortools depends on pandas, but 9.7 does not specify it as dependency
-    "pandas>=2.0.3; python_version < '3.13'",
+    "pandas>=2.0.3; python_version < '3.12'",
     # ortools 9.7 requires protobuf<=6.31.1
-    "protobuf<=6.31.1 ; python_version < '3.13'",
-    "ortools==9.12.4544; python_version >= '3.13'",
+    "protobuf<=6.31.1 ; python_version < '3.12'",
+    "ortools==9.12.4544; python_version >= '3.12'",
     "sympy==1.14.0",
     "unicorn==2.1.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-ortools==9.7.2996 ; python_version < "3.13"
-ortools==9.12.4544 ; python_version >= "3.13"
+ortools==9.7.2996 ; python_version < "3.12"
+ortools==9.12.4544 ; python_version >= "3.12"
 # ortools 9.7 requires protobuf<=6.31.1
-protobuf<=6.31.1 ; python_version < "3.13"
+protobuf<=6.31.1 ; python_version < "3.12"
 # ortools depends on pandas, but 9.7 does not specify it as dependency
-pandas>=2.0.3 ; python_version < "3.13"
+pandas>=2.0.3 ; python_version < "3.12"
 sympy==1.14.0
 unicorn==2.1.4
 black


### PR DESCRIPTION
Currently we are using ortools 9.12 for Python 3.13 onwards as 9.7 does not support it.
However, ortools 9.7 only supports Python 3.12 for linux, not MacOS. This commit uses ortools 9.12 starting from Python 3.12.

Resolves #342 