### PR TITLE
Add support for simplify ">>" and "<<" in <imm>

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -1011,9 +1011,9 @@ class AArch64Instruction(Instruction):
         flag_pattern = "|".join(flaglist)
         dt_pattern = "(?:|2|4|8|16)(?:B|H|S|D|b|h|s|d)"
         imm_pattern = (
-            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
             "|"
-            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
         )
         index_pattern = "[0-9]+"
         barrel_pattern = "(?i:lsl|ror|lsr|asr)\\\\s*"

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -1079,9 +1079,9 @@ class Armv7mInstruction(Instruction):
         # TODO: Notion of dt can be placed with notion for size in FP instructions
         dt_pattern = "(?:|2|4|8|16)(?:B|H|S|D|b|h|s|d)"
         imm_pattern = (
-            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
             "|"
-            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
         )
         index_pattern = "[0-9]+"
         width_pattern = r"(?:\.w|\.n|)"

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -631,9 +631,9 @@ class MVEInstruction(Instruction):
         dt_pattern = "(?:|u|s|i|p|U|S|I|P)(?:8|16|32|64)"
         fdt_pattern = "(?:|f|F)(?:16|32)"
         imm_pattern = (
-            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(#(\\\\w|\\\\s|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
             "|"
-            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=)+)"
+            "(((0[xb])?[0-9a-fA-F]+|/| |-|\\*|\\+|\\(|\\)|=|<<|>>)+)"
         )
         index_pattern = "[0-9]+"
         src = replace_placeholders(src, "imm", imm_pattern, "imm")

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -3,6 +3,7 @@ start:
 // TODO: this is currently incomplete. We should add all instructions
 
 add x2, x1, #64
+add x2, x1, #32<<1
 add x2, x1, 64
 
 eon x2, x2, x1
@@ -31,7 +32,7 @@ orn v27.16b, v28.16b, v29.16b
 eor v30.16b, v31.16b, v0.16b
 ext v0.16b, v1.16b, v2.16b, #8
 sli v3.16b, v4.16b, #2
-sri v1.16b, v2.16b, #4
+sri v1.16b, v2.16b, #2<<1
 trn1 v17.16b, v18.16b, v19.16b
 trn2 v20.16b, v21.16b, v22.16b
 aese v0.16b, v1.16b

--- a/tests/naive/armv8m/instructions.s
+++ b/tests/naive/armv8m/instructions.s
@@ -6,6 +6,7 @@ add r0, r1, r2
 sub r0, r1, r2
 
 ldr r0, [sp, #4]
+ldr r0, [sp, #2<<1]
 ldr r1, [r13, #8]
 
 ldr r0, [sp, #4]
@@ -65,6 +66,7 @@ ldrd r0, r1, [r2]
 ldrd r0, r1, [r2, #16]
 ldrd r0, r1, [r2, #-16]
 ldrd r0, r1, [r2], #16
+ldrd r0, r1, [r2], #8<<1
 ldrd r0, r1, [r2], #-16
 ldrd r0, r1, [r2, #16]!
 ldrd r0, r1, [r2, #-16]!
@@ -149,6 +151,7 @@ sub r0, r1, #16
 
 vshr.u8 q0, q1, #8
 vshr.u16 q0, q1, #16
+vshr.u16 q0, q1, #8<<1
 vshr.u32 q0, q1, #16
 vshr.s8 q0, q1, #8
 vshr.s16 q0, q1, #16
@@ -386,6 +389,7 @@ vhcadd.s8 q2, q0, q1, #270
 vhcadd.s16 q2, q0, q1, #90
 vhcadd.s16 q2, q0, q1, #270
 vhcadd.s32 q2, q0, q1, #90
+vhcadd.s32 q2, q0, q1, #45<<1
 vhcadd.s32 q2, q0, q1, #270
 
 lsr r0, r0, #1


### PR DESCRIPTION
- During PR #341, we noticed that some shifted immediate values need to be handled.

- This PR adds support for simplifying shift operators (<< and >>) applied to immediate values.
   For example: `movs r0, #38 << 1` will be simplified to `movs r0, #76`.
- Apply on following architecture model:
  - `aarch_neon`
  - `arch_v7m`
  - `arch_v81m`