### PR TITLE
Armv7-M: Removing the wrong `args_in_out_different` for ldr/ldrb/ldrh

### DIFF
--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -1854,7 +1854,6 @@ class ldr(Armv7mLoadInstruction):
         obj.increment = None
         obj.pre_index = 0
         obj.addr = obj.args_in[0]
-        obj.args_in_out_different = [(0, 0)]  # Can't have Rd==Ra
         return obj
 
     def write(self):
@@ -1875,7 +1874,6 @@ class ldr_with_imm(Armv7mLoadInstruction):
         obj.increment = None
         obj.pre_index = obj.immediate
         obj.addr = obj.args_in[0]
-        obj.args_in_out_different = [(0, 0)]  # Can't have Rd==Ra
         return obj
 
     def write(self):
@@ -1900,7 +1898,6 @@ class ldrb_with_imm(Armv7mLoadInstruction):
         obj = Armv7mInstruction.build(cls, src)
         obj.increment = None
         obj.pre_index = obj.immediate
-        obj.args_in_out_different = [(0, 0)]  # Can't have Rd==Ra
         obj.addr = obj.args_in[0]
         return obj
 
@@ -1919,7 +1916,6 @@ class ldrh_with_imm(Armv7mLoadInstruction):
         obj = Armv7mInstruction.build(cls, src)
         obj.increment = None
         obj.pre_index = obj.immediate
-        obj.args_in_out_different = [(0, 0)]  # Can't have Rd==Ra
         obj.addr = obj.args_in[0]
         return obj
 


### PR DESCRIPTION
- We discovered this issue during #341, when we tried to optimize some assembly code that included `ldr` instructions. The `args_in_out_different` restriction made it harder for Slothy to find a solution in scenarios where the number of available registers was limited.

- This PR removes the restriction in the `make()` function of `ldr` and `ldr_with_imm`, namely the line:
  `obj.args_in_out_different = [(0, 0)] # Can't have Rd==Ra`.
  we believe this is wrong restriction for `ldr`, `ldr_imm`, `ldrh_with_imm` and `ldrb_with_imm`