### PR TITLE
Armv8.1-M: Extend LeLoop to support letp branch

### DIFF
--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -140,7 +140,7 @@ class RegisterType(Enum):
 
 class LeLoop(Loop):
     """
-    Loop ending in a le instruction.
+    Loop ending in a le/letp instruction.
 
     Example:
 
@@ -148,7 +148,7 @@ class LeLoop(Loop):
 
        loop_lbl:
            {code}
-           le <cnt>, loop_lbl
+           (le|letp) <cnt>, loop_lbl
 
     where cnt is the loop counter in lr.
     """
@@ -156,7 +156,9 @@ class LeLoop(Loop):
     def __init__(self, lbl_start="1", lbl_end="2"):
         super().__init__(lbl_start=lbl_start, lbl_end=lbl_end)
         self.lbl_regex = r"^\s*(?P<label>\w+)\s*:(?P<remainder>.*)$"
-        self.end_regex = (rf"^\s*le\s+((?P<cnt>\w+)|r14)\s*,\s*{lbl_start}",)
+        self.end_regex = (
+            rf"^\s*(?P<instr>le|letp)\s+((?P<cnt>\w+)|r14)\s*,\s*{lbl_start}",
+        )
 
     def start(
         self,
@@ -181,12 +183,12 @@ class LeLoop(Loop):
         yield ".p2align 2"
         yield f"{self.lbl_start}:"
 
-    def end(self, unused, indentation=0):
+    def end(self, other, indentation=0):
         indent = " " * indentation
         lbl_start = self.lbl_start
         if lbl_start.isdigit():
             lbl_start += "b"
-        yield f"{indent}le lr, {lbl_start}"
+        yield f"{indent}{other['instr']} lr, {lbl_start}"
 
 
 class FatalParsingException(Exception):

--- a/tests/naive/armv8m/_test.py
+++ b/tests/naive/armv8m/_test.py
@@ -92,6 +92,20 @@ class LoopLe(OptimizationRunner):
         slothy.optimize_loop("start")
 
 
+class LoopLetp(OptimizationRunner):
+    def __init__(self, var="", arch=Arch_Armv81M, target=Target_CortexM85r1):
+        name = "loop_letp"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.optimize_loop("1")
+
+
 class HintTest(OptimizationRunner):
     def __init__(self):
         super().__init__(
@@ -124,6 +138,7 @@ test_instances = [
     Example2(),
     Example3(),
     LoopLe(),
+    LoopLetp(),
     HintTest(),
     TagTest(),
 ]

--- a/tests/naive/armv8m/loop_letp.s
+++ b/tests/naive/armv8m/loop_letp.s
@@ -1,0 +1,6 @@
+mov r0, #17
+wlstp.u8 lr, r0, 2f
+1:  
+    nop
+    letp lr, 1b
+2:


### PR DESCRIPTION
- Extend `LeLoop()` to support `letp` instruction
- Add `letp` loop test