### PR TITLE
Fix setuptools license deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "slothy"
 version = "0.1.8"
 description = "SLOTHY: Assembly superoptimization via constraint solving"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Hanno Becker"},
     {name = "Amin Abdulrahman"},
@@ -31,7 +31,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Update pyproject.toml to use the new SPDX license expression format:
 - Change `license = {text = "MIT"}` to `license = "MIT"`
 - Remove deprecated `License :: OSI Approved :: MIT License` classifier

See: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license