### PR TITLE
Neon: Set addr for 3 instructions

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -1548,6 +1548,7 @@ class q_ld2_lane_post_inc(Q_Ld2_Lane_Post_Inc):
     def make(cls, src):
         obj = AArch64Instruction.build(cls, src)
         obj.detected_q_ld2_lane_post_inc_pair = False
+        obj.addr = obj.args_in_out[2]
         obj.args_in_out_combinations = [
             ([0, 1], [[f"v{i}", f"v{i+1}"] for i in range(0, 30)])
         ]
@@ -1559,7 +1560,6 @@ class q_ld2_lane_post_inc(Q_Ld2_Lane_Post_Inc):
 
 class q_ld2_lane_post_inc_force_output(Q_Ld2_Lane_Post_Inc):
     pattern = "ld2 { <Va>.<dt>, <Vb>.<dt> }[<index>], [<Xa>], <imm>"
-    # TODO: Model sp dependency
     in_outs = ["Xa"]
     outputs = ["Va", "Vb"]
 
@@ -1569,6 +1569,7 @@ class q_ld2_lane_post_inc_force_output(Q_Ld2_Lane_Post_Inc):
             raise Instruction.ParsingException("Instruction ignored")
 
         obj = AArch64Instruction.build(cls, src)
+        obj.addr = obj.args_in_out[0]
         obj.args_out_combinations = [
             ([0, 1], [[f"v{i}", f"v{i+1}"] for i in range(0, 30)])
         ]
@@ -1605,6 +1606,7 @@ class q_ldr1_post_inc(AArch64Instruction):
         obj = AArch64Instruction.build(cls, src)
         obj.increment = obj.immediate
         obj.pre_index = None
+        obj.addr = obj.args_in_out[0]
         return obj
 
     def write(self):
@@ -2353,6 +2355,12 @@ class ldr_sxtw_wform(AArch64Instruction):
     pattern = "ldr <Wd>, [<Xa>, <Wb>, SXTW <imm>]"
     inputs = ["Xa", "Wb"]
     outputs = ["Wd"]
+
+    @classmethod
+    def make(cls, src):
+        obj = AArch64Instruction.build(cls, src)
+        obj.addr = obj.args_in[0]
+        return obj
 
 
 ############################

--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -304,6 +304,38 @@ class AArch64CStyleComments(OptimizationRunner):
         slothy.optimize(start="start", end="end")
 
 
+class AArch64SelftestAddr(OptimizationRunner):
+    def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
+        name = "aarch64_selftest_addr"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 64
+        # Mark all vector and GPR outputs from loads
+        slothy.config.outputs = [
+            "v0",
+            "v1",
+            "v2",
+            "v3",
+            "v4",
+            "v5",  # vector loads
+            "x21",
+            "x22",
+            "x23",
+            "x24",
+            "x25",
+            "x26",
+            "x27",
+            "x28",  # GPR loads
+        ]
+        slothy.optimize(start="start", end="end")
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexA72),
@@ -327,4 +359,5 @@ test_instances = [
     AArch64LoopBranch(),
     AArch64FusionVeor(),
     AArch64CStyleComments(),
+    AArch64SelftestAddr(),
 ]

--- a/tests/naive/aarch64/aarch64_selftest_addr.s
+++ b/tests/naive/aarch64/aarch64_selftest_addr.s
@@ -1,0 +1,26 @@
+start:
+ld2 { v0.S, v1.S }[1], [x0], #8
+ld1r {v2.4s}, [x1], #4
+ldr q3, [x2, #16]
+ldr q4, [x3], #16
+ld1 {v5.4s}, [x4], #16
+ldr x21, [x5, #8]
+ldp x22, x23, [x6, #16]
+mov w23, #0
+ldr w24, [x7, w23, SXTW #0]
+ldr x25, [x8], #8
+str q6, [x9, #16]
+str q7, [x10], #16
+str x26, [x11, #8]
+stp x27, x12, [x18, #16]
+str x28, [x13], #8
+
+// TODO: Instructions not supported on Cortex-A55
+// ldp q24, q25, [x14, #32]
+// ld4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x15], #64
+// st4 {v30.4s, v31.4s, v0.4s, v1.4s}, [x16], #64
+// ld3 {v2.4s, v3.4s, v4.4s}, [x17], #48
+// st3 {v5.4s, v6.4s, v7.4s}, [x18], #48
+// ld2 {v8.4s, v9.4s}, [x19], #32
+// st2 {v10.4s, v11.4s}, [x20], #32
+end:


### PR DESCRIPTION
For the selftest to properly detect which registers are used as addresses, the model needs to set the addr property. This was missing for 3 instructions:
```
1) ld2 { <Va>.<dt>, <Vb>.<dt> }[<index>], [<Xa>], <imm>
2) ldr <Wd>, [<Xa>, <Wb>, SXTW <imm>]
3) ld1r {<Va>.<dt>}, [<Xa>], <imm>
```
This commit fixes that and also adds a unit test for all memory operations (some currently can't be tested as they are not supported by the A55 model).