### PR TITLE
equ: Allow underscores in names, and spaces in expressions 

### DIFF
--- a/slothy/helper.py
+++ b/slothy/helper.py
@@ -704,7 +704,8 @@ class AsmAllocation:
     # TODO: This is conceptionally different and should be
     # handled in its own class.
     _REGEXP_EQU_TXT = (
-        r"\s*\.equ\s+(?P<key>[A-Za-z0-9\_]+)\s*,\s*(?P<val>[A-Za-z0-9()*/+-]+)"
+        r"\s*\.equ\s+(?P<key>[_a-zA-Z][_a-zA-Z0-9]*)\s*,"
+        r"\s*(?P<val>[A-Za-z0-9()*/+\-\_\s]+)"
     )
 
     _REGEXP_REQ_TXT = r"\s*(?P<alias>\w+)\s+\.req\s+(?P<reg>\w+)"

--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -134,6 +134,34 @@ class AArch64Example0Equ(OptimizationRunner):
         slothy.optimize(start="start", end="end")
 
 
+class AArch64Equ(OptimizationRunner):
+    def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
+        name = "aarch64_equ"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 32
+        slothy.config.outputs = [
+            "v0",
+            "v1",
+            "v2",
+            "v3",
+            "v4",
+            "v5",
+            "v6",
+            "v7",
+            "v8",
+            "v9",
+            "v10",
+        ]
+        slothy.optimize(start="start", end="end")
+
+
 class AArch64Example1(OptimizationRunner):
     def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
         name = "aarch64_simple0_macros"
@@ -343,6 +371,7 @@ test_instances = [
     AArch64Example0(),
     AArch64Example0(target=Target_CortexA72),
     AArch64Example0Equ(),
+    AArch64Equ(),
     AArch64Example1(),
     AArch64Example1(target=Target_CortexA72),
     AArch64Example2(),

--- a/tests/naive/aarch64/aarch64_equ.s
+++ b/tests/naive/aarch64/aarch64_equ.s
@@ -1,0 +1,26 @@
+.equ BASE, 64
+.equ NO_SPACES, (BASE+8)
+.equ SPACE_AFTER_OP, (BASE+ 16)
+.equ SPACE_BEFORE_OP, (BASE +24)
+.equ SPACES_BOTH, (BASE + 32)
+.equ MANY_SPACES, (BASE   +   40)
+.equ WITH_MUL, (BASE*2)
+.equ WITH_DIV, (BASE/2)
+.equ MUL_AND_ADD, (BASE*2+16)
+.equ COMPLEX_EXPR, (BASE + BASE*2 + 64/4)
+.equ NESTED_SYMBOLS, (COMPLEX_EXPR + BASE)
+.equ VERY_COMPLEX, (BASE*4 + NESTED_SYMBOLS/2 - 8)
+
+start:
+ldr q0, [x0, #NO_SPACES]
+ldr q1, [x0, #SPACE_AFTER_OP]
+ldr q2, [x0, #SPACE_BEFORE_OP]
+ldr q3, [x0, #SPACES_BOTH]
+ldr q4, [x0, #MANY_SPACES]
+ldr q5, [x0, #WITH_MUL]
+ldr q6, [x0, #WITH_DIV]
+ldr q7, [x0, #MUL_AND_ADD]
+ldr q8, [x0, #COMPLEX_EXPR]
+ldr q9, [x0, #NESTED_SYMBOLS]
+ldr q10, [x0, #VERY_COMPLEX]
+end:


### PR DESCRIPTION
I noticed that our equ parsing cannot handle underscores and spaces well.
This commit fixes that and adds a test.
