### PR TITLE
Make naming of stack locations configurable

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -1101,12 +1101,28 @@ class Config(NestedPrint, LockAttributes):
             """Allow Slothy to introduce stack spills
 
             When this option is enabled, Slothy will consider the introduction
-            of stack spills to reduce register pressure.
+            of stack spills to reduce register pressure. The naming of stack
+            locations can be customized using spill_stack_loc_prefix.
 
             This option should only be disabled if it is known that the input
             assembly suffers from high register pressure. For example, this can
             be the case for symbolic input assembly."""
             return self._allow_spills
+
+        @property
+        def spill_stack_loc_prefix(self):
+            """
+            Prefix for stack location names in generated assembly when spills
+            are enabled.
+
+            When allow_spills is True, this prefix is used to generate unique stack
+            location names in the format "{prefix}_{index}" (e.g., "STACK_LOC_0",
+            "STACK_LOC_1", etc.). This allows customization of naming conventions
+            to match project requirements.
+
+            Default: "STACK_LOC"
+            """
+            return self._spill_stack_loc_prefix
 
         @property
         def spill_type(self):
@@ -1190,6 +1206,7 @@ class Config(NestedPrint, LockAttributes):
             self._allow_reordering = True
             self._allow_renaming = True
             self._allow_spills = False
+            self._spill_stack_loc_prefix = "STACK_LOC"
             self._spill_type = None
 
             self.lock()
@@ -1241,6 +1258,10 @@ class Config(NestedPrint, LockAttributes):
         @allow_spills.setter
         def allow_spills(self, val):
             self._allow_spills = val
+
+        @spill_stack_loc_prefix.setter
+        def spill_stack_loc_prefix(self, val):
+            self._spill_stack_loc_prefix = val
 
         @spill_type.setter
         def spill_type(self, val):

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -635,7 +635,12 @@ class Result(LockAttributes):
         def gen_restore(reg, loc, vis):
             args = self.config.constraints.spill_type
             yield SourceLine(
-                self.config.arch.Spill.restore(reg, loc, **args)
+                self.config.arch.Spill.restore(
+                    reg,
+                    loc,
+                    prefix=self.config.constraints.spill_stack_loc_prefix,
+                    **args,
+                )
             ).set_length(self.fixlen).set_comment(vis).add_tag(
                 "is_restore", True
             ).add_tag(
@@ -644,9 +649,16 @@ class Result(LockAttributes):
 
         def gen_spill(reg, loc, vis):
             args = self.config.constraints.spill_type
-            yield SourceLine(self.config.arch.Spill.spill(reg, loc, **args)).set_length(
-                self.fixlen
-            ).set_comment(vis).add_tag("is_spill", True).add_tag(
+            yield SourceLine(
+                self.config.arch.Spill.spill(
+                    reg,
+                    loc,
+                    prefix=self.config.constraints.spill_stack_loc_prefix,
+                    **args,
+                )
+            ).set_length(self.fixlen).set_comment(vis).add_tag(
+                "is_spill", True
+            ).add_tag(
                 "writes", f"stack_{loc}"
             )
 

--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -4656,11 +4656,11 @@ class vuaddlv_sform(AArch64Instruction):
 
 
 class Spill:
-    def spill(reg, loc):
-        return f"str {reg}, [sp, #STACK_LOC_{loc}]"
+    def spill(reg, loc, prefix="STACK_LOC"):
+        return f"str {reg}, [sp, #{prefix}_{loc}]"
 
-    def restore(reg, loc):
-        return f"ldr {reg}, [sp, #STACK_LOC_{loc}]"
+    def restore(reg, loc, prefix="STACK_LOC"):
+        return f"ldr {reg}, [sp, #{prefix}_{loc}]"
 
 
 # In a pair of vins writing both 64-bit lanes of a vector, mark the

--- a/slothy/targets/arm_v7m/arch_v7m.py
+++ b/slothy/targets/arm_v7m/arch_v7m.py
@@ -2331,7 +2331,7 @@ class bne(Armv7mBranch):
 
 
 class Spill:
-    def spill(reg, loc, spill_to_vreg=None):
+    def spill(reg, loc, spill_to_vreg=None, prefix="STACK_LOC"):
         """Generates the instruction text for a spill to either
         the stack or the FPR. If spill_to_vreg is None (default),
         the spill goes to the stack. Otherwise, spill_to_vreg must
@@ -2339,12 +2339,12 @@ class Spill:
         which should be used as a stack. For example, passing 8 would
         spill to s8,s9,.. ."""
         if spill_to_vreg is None:
-            return f"str {reg}, [sp, #STACK_LOC_{loc}]"
+            return f"str {reg}, [sp, #{prefix}_{loc}]"
         else:
             vreg_base = int(spill_to_vreg)
             return f"vmov s{vreg_base+int(loc)}, {reg}"
 
-    def restore(reg, loc, spill_to_vreg=None):
+    def restore(reg, loc, spill_to_vreg=None, prefix="STACK_LOC"):
         """Generates the instruction text for a spill restore from either
         the stack or the FPR. If spill_to_vreg is None (default),
         the spill goes to the stack. Otherwise, spill_to_vreg must
@@ -2352,7 +2352,7 @@ class Spill:
         which should be used as a stack. For example, passing 8 would
         spill to s8,s9,.. ."""
         if spill_to_vreg is None:
-            return f"ldr {reg}, [sp, #STACK_LOC_{loc}]"
+            return f"ldr {reg}, [sp, #{prefix}_{loc}]"
         else:
             vreg_base = int(spill_to_vreg)
             return f"vmov {reg}, s{vreg_base+int(loc)}"


### PR DESCRIPTION
- Resolves: #230
- The commit allows users to specify a custom prefix for stack location names during spill/restore operations when a specific naming convention is required.
- Currently, this change has been tested via the mlkem-native PR:
  https://github.com/pq-code-package/mlkem-native/pull/1396, 
  and the optimization ran successfully using the MLK_STACK_LOC_ prefix.