### PR TITLE
AArch64: add support fo uxtb/sxtb

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -2811,6 +2811,18 @@ class ubfx(AArch64Logical):
     outputs = ["Xd"]
 
 
+class sxtb(AArch64Logical):
+    pattern = "sxtb <Xd>, <Wa>"
+    inputs = ["Wa"]
+    outputs = ["Xd"]
+
+
+class uxtb(AArch64Logical):
+    pattern = "uxtb <Wd>, <Wa>"
+    inputs = ["Wa"]
+    outputs = ["Wd"]
+
+
 class extr(AArch64Logical):  # TODO! Review this...
     pattern = "extr <Xd>, <Xa>, <Xb>, <imm>"
     inputs = ["Xa", "Xb"]

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -91,6 +91,8 @@ from slothy.targets.aarch64.aarch64_neon import (
     Ld3,
     St2,
     Ld2,
+    sxtb,
+    uxtb,
     umov_d,
     mov_d01,
     mov_b00,
@@ -428,6 +430,8 @@ execution_units = {
         lsr,
         eor_wform,
         eon_wform,
+        sxtb,
+        uxtb,
     ): ExecutionUnit.SCALAR(),
     AArch64ConditionalCompare: ExecutionUnit.SCALAR(),
     # NOTE: AESE/AESMC and AESD/AESIMC pairs can be dual-issued on A55 but this
@@ -516,6 +520,7 @@ inverse_throughput = {
     AESInstruction: 1,
     fmov_s_form: 1,  # from double/single to gen reg
     vdup_w: 1,
+    (sxtb, uxtb): 1,
 }
 
 default_latencies = {
@@ -610,6 +615,7 @@ default_latencies = {
     # is not modeled
     AESInstruction: 2,
     fmov_s_form: 1,  # from double/single to gen reg
+    (sxtb, uxtb): 1,
 }
 
 

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -182,5 +182,7 @@ lsr x2, x2, x3
 movk x1, #0x3fff, lsl 16
 movk x1, #0xfffe, lsl 32
 movk x1, #0x3fff, lsl 48
+sxtb x2, w28
+uxtb w28, w29
 
 end:


### PR DESCRIPTION
- Resolves: #389

This commit add the sxtb and uxtb instruction support the a55, a72, neoverse_n1 model

- `sxtb`, `uxtb`
  - a55 SWOG (page: 21 of 48)
    - latency: 1
    - Inverse throughput: 1 (2 ^ -1 )
    - Utilized Pipelines: SCALAR (stick `AArch64Logical` instruction)

  - a72 SWOG (page: 12 of 42) (alias of `UBFM`, `SBFM`, set by `AArch64Logical`)
    - latency: 1
    - Inverse throughput: 1 (2 ^ -1)
    - Utilized Pipelines: I0/I1

  - neoverse_n1 SWOG (page: 19 of 66) (alias of `UBFM`, `SBFM`, set by `AArch64Logical`)
    - latency: 1
    - Inverse throughput: 1 ( 3^ -1)
    - Utilized Pipelines: I