### PR TITLE
Update ortools to 9.15.6755 for all Python versions

### DIFF
--- a/.github/workflows/test_basic.yaml
+++ b/.github/workflows/test_basic.yaml
@@ -84,7 +84,7 @@ jobs:
       run: |
         python3 example.py --examples ntt_kyber_1_23_45_67_m55,ntt_dilithium_12_34_56_78_m55 --timeout=300
   examples_ntt_kyber_dilithium_neon_core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "ortools==9.7.2996; python_version < '3.12'",
-    # ortools depends on pandas, but 9.7 does not specify it as dependency
-    "pandas>=2.0.3; python_version < '3.12'",
-    # ortools 9.7 requires protobuf<=6.31.1
-    "protobuf<=6.31.1; python_version < '3.12'",
-    "ortools==9.15.6755; python_version >= '3.12'",
+    "ortools==9.15.6755",
     "sympy==1.14.0",
     "unicorn==2.1.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
-ortools==9.7.2996 ; python_version < "3.12"
-ortools==9.15.6755 ; python_version >= "3.12"
-# ortools 9.7 requires protobuf<=6.31.1
-protobuf<=6.31.1 ; python_version < "3.12"
-# ortools depends on pandas, but 9.7 does not specify it as dependency
-pandas>=2.0.3 ; python_version < "3.12"
+ortools==9.15.6755
 sympy==1.14.0
 unicorn==2.1.4
 black==26.3.1


### PR DESCRIPTION
Add Python 3.14 to test matrix and classifiers. Remove version-specific ortools dependencies and workarounds for older versions.