### PR TITLE
Update ortools to 9.15.6755 for Python >= 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,12 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: 
+        python-version:
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-ubuntu

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![Python 3.11](https://img.shields.io/badge/Python-3.11-blue?logo=python)
 ![Python 3.12](https://img.shields.io/badge/Python-3.12-blue?logo=python)
 ![Python 3.13](https://img.shields.io/badge/Python-3.13-blue?logo=python)
+![Python 3.14](https://img.shields.io/badge/Python-3.14-blue?logo=python)
 
 ## About SLOTHY
 
@@ -135,7 +136,7 @@ SLOTHY has been successfully used on
 - Ubuntu-21.10 and up (64-bit),
 - macOS Monterey 12.6 and up.
 
-SLOTHY supports Python 3.9 up to 3.13. For development Python >= 3.10 is required.
+SLOTHY supports Python 3.9 up to 3.14. For development Python >= 3.11 is required.
 See [requirements.txt](requirements.txt) for package requirements, and install via `pip install -r requirements.txt`.
 
 **Note:** `requirements.txt` pins versions for reproducibility. If you already have newer versions of some dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Compilers",
     "Topic :: System :: Hardware",
@@ -48,8 +49,8 @@ dependencies = [
     # ortools depends on pandas, but 9.7 does not specify it as dependency
     "pandas>=2.0.3; python_version < '3.12'",
     # ortools 9.7 requires protobuf<=6.31.1
-    "protobuf<=6.31.1 ; python_version < '3.12'",
-    "ortools==9.12.4544; python_version >= '3.12'",
+    "protobuf<=6.31.1; python_version < '3.12'",
+    "ortools==9.15.6755; python_version >= '3.12'",
     "sympy==1.14.0",
     "unicorn==2.1.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ortools==9.7.2996 ; python_version < "3.12"
-ortools==9.12.4544 ; python_version >= "3.12"
+ortools==9.15.6755 ; python_version >= "3.12"
 # ortools 9.7 requires protobuf<=6.31.1
 protobuf<=6.31.1 ; python_version < "3.12"
 # ortools depends on pandas, but 9.7 does not specify it as dependency


### PR DESCRIPTION
Keep ortools 9.7.2996 for Python < 3.12 to maintain compatibility. Use ortools 9.15.6755 for Python 3.12+. Add Python 3.14 support.

- Alternative to #397 