### PR TITLE
[helper] Add `irp` and `rept` assembly directives

### DIFF
--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -57,9 +57,9 @@ from slothy.core.core import Config
 from slothy.core.heuristics import Heuristics
 from slothy.helper import (
     AsmAllocation,
-    AsmMacro,
     AsmHelper,
     AsmIfElse,
+    unfold_all_directives,
     CPreprocessor,
     SourceLine,
     LLVM_Mca,
@@ -272,9 +272,9 @@ class Slothy:
 
         body = SourceLine.split_semicolons(body)
 
-        # Unfold macros
+        # Unfold macros and directives
         if macros is True:
-            body = AsmMacro.unfold_all_macros(
+            body = unfold_all_directives(
                 pre, body, inherit_comments=c.inherit_macro_comments
             )
 
@@ -380,7 +380,7 @@ class Slothy:
             Slothy._dump("preprocessed", body, self.logger, err=False)
 
         body = SourceLine.split_semicolons(body)
-        body = AsmMacro.unfold_all_macros(
+        body = unfold_all_directives(
             pre, body, inherit_comments=c.inherit_macro_comments
         )
         body = AsmAllocation.unfold_all_aliases(c.register_aliases, body)
@@ -471,7 +471,7 @@ class Slothy:
         c.add_aliases(aliases)
         c.outputs = outputs
 
-        body = AsmMacro.unfold_all_macros(
+        body = unfold_all_directives(
             pre, body, inherit_comments=c.inherit_macro_comments
         )
         body = AsmAllocation.unfold_all_aliases(c.register_aliases, body)
@@ -493,7 +493,7 @@ class Slothy:
         aliases = AsmAllocation.parse_allocs(pre)
         c.add_aliases(aliases)
 
-        body = AsmMacro.unfold_all_macros(
+        body = unfold_all_directives(
             pre, body, inherit_comments=c.inherit_macro_comments
         )
         body = AsmAllocation.unfold_all_aliases(c.register_aliases, body)
@@ -612,7 +612,7 @@ class Slothy:
             Slothy._dump("preprocessed", body, self.logger, err=False)
 
         body = SourceLine.split_semicolons(body)
-        body = AsmMacro.unfold_all_macros(
+        body = unfold_all_directives(
             early, body, inherit_comments=c.inherit_macro_comments
         )
         body = AsmAllocation.unfold_all_aliases(c.register_aliases, body)

--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -410,6 +410,60 @@ class AArch64SelftestInitialRegs(OptimizationRunner):
         slothy.optimize_loop("start")
 
 
+class AArch64Directives(OptimizationRunner):
+    def __init__(self, var="", arch=AArch64_Neon, target=Target_CortexA55):
+        name = "aarch64_directives"
+        infile = name
+
+        super().__init__(
+            infile, name, rename=True, arch=arch, target=target, base_dir="tests"
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.inputs_are_outputs = True
+        slothy.config.constraints.stalls_first_attempt = 32
+
+        # Basic tests
+        slothy.optimize(start="start_rept", end="end_rept")  # 5 instructions
+        slothy.optimize(start="start_irp", end="end_irp")  # 3 instructions
+
+        # Macro/directive interaction
+        slothy.optimize(
+            start="start_irp_in_macro", end="end_irp_in_macro"
+        )  # 2 instructions
+        slothy.optimize(
+            start="start_macro_in_irp", end="end_macro_in_irp"
+        )  # 3 instructions
+
+        # .rept with \+ counter
+        slothy.optimize(
+            start="start_rept_counter", end="end_rept_counter"
+        )  # 3 instructions
+
+        # Nested directives
+        slothy.optimize(
+            start="start_nested_rept", end="end_nested_rept"
+        )  # 4 instructions
+        slothy.optimize(
+            start="start_rept_in_irp", end="end_rept_in_irp"
+        )  # 4 instructions
+        slothy.optimize(
+            start="start_irp_in_rept", end="end_irp_in_rept"
+        )  # 4 instructions
+
+        # Combined .rept counter and macro
+        slothy.optimize(
+            start="start_rept_macro_counter", end="end_rept_macro_counter"
+        )  # 3 instructions
+
+        # Edge cases
+        slothy.optimize(
+            start="start_rept_zero", end="end_rept_zero"
+        )  # 2 instructions (no .rept output)
+        slothy.optimize(start="start_irp_single", end="end_irp_single")  # 1 instruction
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexA72),
@@ -437,4 +491,5 @@ test_instances = [
     AArch64CStyleComments(),
     AArch64SelftestAddr(),
     AArch64SelftestInitialRegs(),
+    AArch64Directives(),
 ]

--- a/tests/naive/aarch64/aarch64_directives.s
+++ b/tests/naive/aarch64/aarch64_directives.s
@@ -1,0 +1,96 @@
+// Basic .rept test
+start_rept:
+.rept 5
+    add x1, x1, x2
+.endr
+end_rept:
+
+// Basic .irp test
+start_irp:
+.irp param,x2,x3,x4
+    add x1, x1, \param
+.endr
+end_irp:
+
+// .irp inside a macro
+.macro test_irp, my_reg
+    .irp param,x1,x2
+        sub \my_reg, \my_reg, \param
+    .endr
+.endm
+
+start_irp_in_macro:
+test_irp x1
+end_irp_in_macro:
+
+// macro inside .irp
+.macro some_macro, my_reg
+    sub \my_reg, \my_reg, \my_reg
+.endm
+
+start_macro_in_irp:
+.irp param,x2,x3,x4
+    some_macro \param
+.endr
+end_macro_in_irp:
+
+// .rept with \+ iteration counter (0-indexed)
+start_rept_counter:
+.rept 3
+    add x\+, x\+, x5
+.endr
+end_rept_counter:
+
+// Nested .rept
+start_nested_rept:
+.rept 2
+    .rept 2
+        add x1, x1, x2
+    .endr
+.endr
+end_nested_rept:
+
+// .rept inside .irp
+start_rept_in_irp:
+.irp reg,x1,x2
+    .rept 2
+        add \reg, \reg, x5
+    .endr
+.endr
+end_rept_in_irp:
+
+// .irp inside .rept
+start_irp_in_rept:
+.rept 2
+    .irp param,x3,x4
+        add x1, x1, \param
+    .endr
+.endr
+end_irp_in_rept:
+
+// Combined \+ and macro in .rept
+.macro indexed_op, idx
+    add x1, x1, x\idx
+.endm
+
+start_rept_macro_counter:
+.rept 3
+    indexed_op \+
+.endr
+end_rept_macro_counter:
+
+// .rept 0 should produce no output
+start_rept_zero:
+add x1, x1, x2
+.rept 0
+    sub x1, x1, x3
+.endr
+add x1, x1, x4
+end_rept_zero:
+
+// .irp with single value
+start_irp_single:
+.irp param,x2
+    add x1, x1, \param
+.endr
+end_irp_single:


### PR DESCRIPTION
* Adds support for `irp` and `rept` assembly directives
* Add test cases
* Introduce call to resolve directives into SLOTHY's core

Resolves #405 