### PR TITLE
Correct vmull (polynomial) model on Cortex-M85 r1

### DIFF
--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -2622,3 +2622,24 @@ def find_class(src):
         if isinstance(src, inst_class):
             return inst_class
     raise Exception("Couldn't find instruction class")
+
+
+def is_dt_form_of(instr_class, dts=None):
+    if not isinstance(instr_class, list):
+        instr_class = [instr_class]
+
+    def _intersects(ls_a, ls_b):
+        if not isinstance(ls_a, list):
+            ls_a = [ls_a]
+        return len([a for a in ls_a if a in ls_b]) > 0
+
+    def _check_instr_dt(src):
+        # Check if src is an instance of any of the instruction classes
+        # (supports inheritance)
+        for cls in instr_class:
+            if isinstance(src, cls):
+                if dts is None or _intersects(src.datatype, dts):
+                    return True
+        return False
+
+    return _check_instr_dt

--- a/tests/naive/armv8m/instructions.s
+++ b/tests/naive/armv8m/instructions.s
@@ -132,6 +132,9 @@ vmullb.s32 q2, q0, q1
 vmullb.p8 q5, q4, q0
 vmullt.p8 q4, q4, q0
 
+vmullb.p16 q5, q4, q0
+vmullt.p16 q4, q4, q0
+
 vdup.u8 q0, r0
 vdup.u16 q0, r0
 vdup.u32 q0, r0


### PR DESCRIPTION
This PR corrects the execution model of vmull (polynomial) according
to the Cortex-M85 SWOG (MVE integer vector instructions).

The correct model is:

  - ExecutionUnit: Group A
  - Latency: 1
  - Inverse throughput: 2

The polynomial form must be modeled separately from vmull (integer)
according to the souceLine' s datatype
This PR adds three helper functions:

  - is_dt_form_of()

This helper function are referenced from `aarch64_neon.py` and distinguish
between vmull (integer) and vmull (polynomial) based on the operand
data type. 