### PR TITLE
Fix typo: vars -> bvars in _add_path_constraint_from

### DIFF
--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -2544,7 +2544,7 @@ class SlothyBase(LockAttributes):
                 cb().OnlyEnforceIf(bvar)
             return
 
-        assert len(cb_lst) == len(vars)
+        assert len(cb_lst) == len(bvars)
         for cb, bvar in zip(cb_lst, bvars):
             constraints = [bvar]
             if self._is_low(producer):


### PR DESCRIPTION
`vars` is a Python built-in function. Should be the variable also used in the surounding code, `bvars`. 