### PR TITLE
Add CLI support for RISC_V architecture and XuanTie_C908 target

### DIFF
--- a/slothy/targets/query.py
+++ b/slothy/targets/query.py
@@ -52,6 +52,9 @@ from slothy.targets.aarch64 import (
     apple_m1_icestorm_experimental as Target_AppleM1_Icestorm_Experimental,
 )
 
+from slothy.targets.riscv import riscv as Arch_RISC_V
+from slothy.targets.riscv import xuantie_c908 as Target_XuanTie_C908
+
 
 class UnknownTarget(Exception):
     """Exception raised when an unknown architecture or microarchitecture
@@ -65,6 +68,7 @@ class Archery:
         "Arm_v7M": Arch_Armv7M,
         "Arm_v81M": Arch_Armv81M,
         "Arm_AArch64": AArch64_Neon,
+        "RISC_V": Arch_RISC_V,
     }
 
     _targets = {
@@ -78,6 +82,7 @@ class Archery:
         "Arm_Big_experimental": Target_Big_Experimental,
         "Apple_M1_firestorm_experimental": Target_AppleM1_Firestorm_Experimental,
         "Apple_M1_icestorm_experimental": Target_AppleM1_Icestorm_Experimental,
+        "XuanTie_C908": Target_XuanTie_C908,
     }
 
     @staticmethod


### PR DESCRIPTION
This PR adds CLI support for the RISC_V architecture and the XuanTie_C908 target. 