### PR TITLE
Prefer caller-save registers and emit callee-save clobber comments

### DIFF
--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -530,6 +530,23 @@ class Config(NestedPrint, LockAttributes):
         return self._with_llvm_mca_after
 
     @property
+    def emit_clobbered_callee_saves_comment(self):
+        """If True, prepend a comment to the output listing callee-saved registers
+        (per the ISA calling convention) that are clobbered by the optimized code.
+
+        This is useful for understanding the ABI cost of a snippet and for
+        constructing correct save/restore sequences around it.
+
+        Requires the ISA model to define callee_saved_registers(). When the ISA
+        model does not provide this method the option has no effect.
+        """
+        return self._emit_clobbered_callee_saves_comment
+
+    @emit_clobbered_callee_saves_comment.setter
+    def emit_clobbered_callee_saves_comment(self, val):
+        self._emit_clobbered_callee_saves_comment = val
+
+    @property
     def compiler_binary(self):
         """The compiler binary to be used.
 
@@ -619,6 +636,7 @@ class Config(NestedPrint, LockAttributes):
                 self.constraints.move_stalls_to_bottom is True,
                 self.constraints.minimize_register_usage is not None,
                 self.constraints.minimize_use_of_extra_registers is not None,
+                self.constraints.prefer_caller_save_registers is True,
                 self.target.has_min_max_objective(self),
             ]
         )
@@ -1198,6 +1216,35 @@ class Config(NestedPrint, LockAttributes):
             return self._minimize_spills
 
         @property
+        def prefer_caller_save_registers(self):
+            """Bias register allocation toward caller-save registers.
+
+            Adds solver hints preferring registers that already appear in the
+            input code (regardless of whether they are caller- or callee-saved),
+            and discouraging callee-saved registers when new registers must be
+            introduced.  Additionally, a secondary solver objective minimises the
+            number of distinct callee-saved registers used, applied after the
+            primary stall-minimisation objective.
+
+            Because the preference is expressed through hints and a secondary
+            objective, optimal scheduling is never sacrificed: if callee-saved
+            registers are the only way to achieve minimum stalls, they will still
+            be used.
+
+            This option subsumes hints.rename_hint_orig_rename: when both are
+            enabled the orig-rename hint is already covered, so enabling
+            rename_hint_orig_rename on top is harmless but redundant.
+
+            Requires the ISA model to define callee_saved_registers(). When the
+            ISA model does not provide this method the option has no effect.
+            """
+            return self._prefer_caller_save_registers
+
+        @prefer_caller_save_registers.setter
+        def prefer_caller_save_registers(self, val):
+            self._prefer_caller_save_registers = val
+
+        @property
         def max_displacement(self):
             """The maximum relative displacement of an instruction.
 
@@ -1236,6 +1283,7 @@ class Config(NestedPrint, LockAttributes):
             self.minimize_register_usage = None
             self.minimize_use_of_extra_registers = None
             self.allow_extra_registers = {}
+            self._prefer_caller_save_registers = False
 
             self._stalls_allowed = 0
             self._stalls_maximum_attempt = 512
@@ -1336,8 +1384,16 @@ class Config(NestedPrint, LockAttributes):
 
         @property
         def rename_hint_orig_rename(self):
-            """Hint at using the initial program order for the
-            program order variables."""
+            """Hint the solver to keep each instruction's original output register.
+
+            For each instruction, adds a solver hint favouring the register that
+            was used in the input code.
+
+            Note: when constraints.prefer_caller_save_registers is also enabled,
+            that option already covers this hint (it biases all original registers,
+            not just each instruction's own output). Enabling both is harmless
+            but redundant for the hint on the exact original register.
+            """
             return self._rename_hint_orig_rename
 
         @property
@@ -1439,6 +1495,7 @@ class Config(NestedPrint, LockAttributes):
         self._llvm_mca_issue_width_overwrite = False
         self._with_llvm_mca_before = False
         self._with_llvm_mca_after = False
+        self._emit_clobbered_callee_saves_comment = True
         self._max_solutions = 64
         self._timeout = None
         self._retry_timeout = None

--- a/slothy/core/config.py
+++ b/slothy/core/config.py
@@ -553,6 +553,23 @@ class Config(NestedPrint, LockAttributes):
         return self._with_llvm_mca_after
 
     @property
+    def emit_clobbered_callee_saves_comment(self):
+        """If True, prepend a comment to the output listing callee-saved registers
+        (per the ISA calling convention) that are clobbered by the optimized code.
+
+        This is useful for understanding the ABI cost of a snippet and for
+        constructing correct save/restore sequences around it.
+
+        Requires the ISA model to define callee_saved_registers(). When the ISA
+        model does not provide this method the option has no effect.
+        """
+        return self._emit_clobbered_callee_saves_comment
+
+    @emit_clobbered_callee_saves_comment.setter
+    def emit_clobbered_callee_saves_comment(self, val):
+        self._emit_clobbered_callee_saves_comment = val
+
+    @property
     def compiler_binary(self):
         """The compiler binary to be used.
 
@@ -642,6 +659,7 @@ class Config(NestedPrint, LockAttributes):
                 self.constraints.move_stalls_to_bottom is True,
                 self.constraints.minimize_register_usage is not None,
                 self.constraints.minimize_use_of_extra_registers is not None,
+                self.constraints.prefer_caller_save_registers is True,
                 self.target.has_min_max_objective(self),
             ]
         )
@@ -1221,6 +1239,35 @@ class Config(NestedPrint, LockAttributes):
             return self._minimize_spills
 
         @property
+        def prefer_caller_save_registers(self):
+            """Bias register allocation toward caller-save registers.
+
+            Adds solver hints preferring registers that already appear in the
+            input code (regardless of whether they are caller- or callee-saved),
+            and discouraging callee-saved registers when new registers must be
+            introduced.  Additionally, a secondary solver objective minimises the
+            number of distinct callee-saved registers used, applied after the
+            primary stall-minimisation objective.
+
+            Because the preference is expressed through hints and a secondary
+            objective, optimal scheduling is never sacrificed: if callee-saved
+            registers are the only way to achieve minimum stalls, they will still
+            be used.
+
+            This option subsumes hints.rename_hint_orig_rename: when both are
+            enabled the orig-rename hint is already covered, so enabling
+            rename_hint_orig_rename on top is harmless but redundant.
+
+            Requires the ISA model to define callee_saved_registers(). When the
+            ISA model does not provide this method the option has no effect.
+            """
+            return self._prefer_caller_save_registers
+
+        @prefer_caller_save_registers.setter
+        def prefer_caller_save_registers(self, val):
+            self._prefer_caller_save_registers = val
+
+        @property
         def max_displacement(self):
             """The maximum relative displacement of an instruction.
 
@@ -1259,6 +1306,7 @@ class Config(NestedPrint, LockAttributes):
             self.minimize_register_usage = None
             self.minimize_use_of_extra_registers = None
             self.allow_extra_registers = {}
+            self._prefer_caller_save_registers = False
 
             self._stalls_allowed = 0
             self._stalls_maximum_attempt = 512
@@ -1359,8 +1407,16 @@ class Config(NestedPrint, LockAttributes):
 
         @property
         def rename_hint_orig_rename(self):
-            """Hint at using the initial program order for the
-            program order variables."""
+            """Hint the solver to keep each instruction's original output register.
+
+            For each instruction, adds a solver hint favouring the register that
+            was used in the input code.
+
+            Note: when constraints.prefer_caller_save_registers is also enabled,
+            that option already covers this hint (it biases all original registers,
+            not just each instruction's own output). Enabling both is harmless
+            but redundant for the hint on the exact original register.
+            """
             return self._rename_hint_orig_rename
 
         @property
@@ -1462,6 +1518,7 @@ class Config(NestedPrint, LockAttributes):
         self._llvm_mca_issue_width_overwrite = False
         self._with_llvm_mca_before = False
         self._with_llvm_mca_after = False
+        self._emit_clobbered_callee_saves_comment = True
         self._max_solutions = 64
         self._timeout = None
         self._retry_timeout = None

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -1170,6 +1170,17 @@ class Result(LockAttributes):
         self._output_renamings = v
 
     @property
+    def clobbered_callee_saved(self):
+        """Set of callee-saved registers (per the ISA calling convention) that
+        are clobbered by the optimized code.  Empty when the ISA model does not
+        define callee_saved_registers()."""
+        return self._clobbered_callee_saved
+
+    @clobbered_callee_saved.setter
+    def clobbered_callee_saved(self, val):
+        self._clobbered_callee_saved = val
+
+    @property
     def stalls(self):
         """The number of stalls in the optimization result.
 
@@ -1561,6 +1572,7 @@ class Result(LockAttributes):
         self._optimization_user_time = None
         self._spills = {}
         self._restores = {}
+        self._clobbered_callee_saved = set()
 
         self.lock()
 
@@ -2204,6 +2216,7 @@ class SlothyBase(LockAttributes):
 
         self._extract_spills()
         self._extract_code()
+        self._result.clobbered_callee_saved = self._compute_clobbered_callee_saved()
         self._result.selfcheck_with_fixup(self.logger.getChild("selfcheck"))
         self._result.offset_fixup(self.logger.getChild("fixup"))
 
@@ -2474,6 +2487,17 @@ class SlothyBase(LockAttributes):
             for s in self._result.code:
                 self.logger.result.debug("> " + s.to_string())
 
+    def _compute_clobbered_callee_saved(self):
+        if not hasattr(self.arch.RegisterType, "callee_saved_registers"):
+            return set()
+        callee_saved = set(self.arch.RegisterType.callee_saved_registers())
+        used = set()
+        for t in self._get_nodes():
+            used.update(t.inst.args_out)
+            used.update(t.inst.args_in)
+            used.update(t.inst.args_in_out)
+        return callee_saved & used
+
     def _add_path_constraint(self, consumer, producer, cb):
         """Add model constraint cb() relating to the pair of producer-consumer
         instructions
@@ -2735,12 +2759,37 @@ class SlothyBase(LockAttributes):
 
         self.logger.debug("Adding variables for register allocation...")
 
+        # One Boolean per callee-saved register: True iff that register is used
+        # anywhere in the optimized output.  Linked to register_usage_vars via
+        # MaxEquality in _add_constraints_register_renaming and minimized as a
+        # secondary objective in _add_objective, so the solver prefers
+        # caller-save registers without ever sacrificing stall minimization.
+        callee_saved = set()
+        self._model._callee_saved_used = {}
+        if self.config.constraints.prefer_caller_save_registers and hasattr(
+            self.arch.RegisterType, "callee_saved_registers"
+        ):
+            callee_saved = set(self.arch.RegisterType.callee_saved_registers())
+            self._model._callee_saved_used = {
+                reg: self._NewBoolVar(f"callee_saved_used[{reg}]")
+                for reg in self.arch.RegisterType.callee_saved_registers()
+            }
+
         if self.config.constraints.minimize_register_usage is not None:
             ty = self.config.constraints.minimize_register_usage
             regs = self.arch.RegisterType.list_registers(ty)
             self._model._register_used = {
                 reg: self._NewBoolVar(f"reg_used[{reg}]") for reg in regs
             }
+
+        # Collect registers appearing in the original (pre-renaming) code so
+        # that hints can prefer them.  Input/output pseudo-nodes are excluded
+        # because their registers are fixed by the interface, not by the code.
+        orig_regs = set()
+        for t in self._get_nodes():
+            orig_regs.update(t.inst.args_out)
+            orig_regs.update(t.inst.args_in)
+            orig_regs.update(t.inst.args_in_out)
 
         # Create variables for register renaming
 
@@ -2821,6 +2870,13 @@ class SlothyBase(LockAttributes):
                 if self.config.hints.rename_hint_orig_rename:
                     if arg_out in candidates_restricted:
                         self._AddHint(var_dict[arg_out], True)
+
+                if self.config.constraints.prefer_caller_save_registers:
+                    for out_reg, var in var_dict.items():
+                        if out_reg in orig_regs:
+                            self._AddHint(var, True)
+                        elif out_reg in callee_saved:
+                            self._AddHint(var, False)
 
         # For convenience, also add references to the variables governing the
         # register renaming for input and input/output arguments.
@@ -3139,6 +3195,13 @@ class SlothyBase(LockAttributes):
                     self._AddMaxEquality(self._model._register_used[reg], arr)
                 else:
                     self._Add(self._model._register_used[reg] == False)  # noqa: E712
+
+        for reg, used_var in self._model._callee_saved_used.items():
+            arr = self._model.register_usage_vars.get(reg, [])
+            if len(arr) > 0:
+                self._AddMaxEquality(used_var, arr)
+            else:
+                self._Add(used_var == False)  # noqa: E712
 
         for t in self._get_nodes(allnodes=True):
             can_spill = True
@@ -3974,6 +4037,15 @@ class SlothyBase(LockAttributes):
                     minlist = lst
                 else:
                     maxlist = lst
+
+        # Secondary objective: prefer caller-save registers.
+        # This runs only in the force_objective (step-2 re-optimization) path,
+        # where stalls are already fixed via a hard constraint.
+        if force_objective and self._model._callee_saved_used and len(maxlist) == 0:
+            callee_vars = list(self._model._callee_saved_used.values())
+            if len(minlist) == 0:
+                minlist = callee_vars
+                name = "minimize callee-saved register usage"
 
         self._model.objective_printer = printer
         self._model.objective_vars = objective_vars

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -1170,6 +1170,17 @@ class Result(LockAttributes):
         self._output_renamings = v
 
     @property
+    def clobbered_callee_saved(self):
+        """Set of callee-saved registers (per the ISA calling convention) that
+        are clobbered by the optimized code.  Empty when the ISA model does not
+        define callee_saved_registers()."""
+        return self._clobbered_callee_saved
+
+    @clobbered_callee_saved.setter
+    def clobbered_callee_saved(self, val):
+        self._clobbered_callee_saved = val
+
+    @property
     def stalls(self):
         """The number of stalls in the optimization result.
 
@@ -1561,6 +1572,7 @@ class Result(LockAttributes):
         self._optimization_user_time = None
         self._spills = {}
         self._restores = {}
+        self._clobbered_callee_saved = set()
 
         self.lock()
 
@@ -2206,6 +2218,7 @@ class SlothyBase(LockAttributes):
 
         self._extract_spills()
         self._extract_code()
+        self._result.clobbered_callee_saved = self._compute_clobbered_callee_saved()
         self._result.selfcheck_with_fixup(self.logger.getChild("selfcheck"))
         self._result.offset_fixup(self.logger.getChild("fixup"))
 
@@ -2476,6 +2489,17 @@ class SlothyBase(LockAttributes):
             for s in self._result.code:
                 self.logger.result.debug("> " + s.to_string())
 
+    def _compute_clobbered_callee_saved(self):
+        if not hasattr(self.arch.RegisterType, "callee_saved_registers"):
+            return set()
+        callee_saved = set(self.arch.RegisterType.callee_saved_registers())
+        used = set()
+        for t in self._get_nodes():
+            used.update(t.inst.args_out)
+            used.update(t.inst.args_in)
+            used.update(t.inst.args_in_out)
+        return callee_saved & used
+
     def _add_path_constraint(self, consumer, producer, cb):
         """Add model constraint cb() relating to the pair of producer-consumer
         instructions
@@ -2737,12 +2761,37 @@ class SlothyBase(LockAttributes):
 
         self.logger.debug("Adding variables for register allocation...")
 
+        # One Boolean per callee-saved register: True iff that register is used
+        # anywhere in the optimized output.  Linked to register_usage_vars via
+        # MaxEquality in _add_constraints_register_renaming and minimized as a
+        # secondary objective in _add_objective, so the solver prefers
+        # caller-save registers without ever sacrificing stall minimization.
+        callee_saved = set()
+        self._model._callee_saved_used = {}
+        if self.config.constraints.prefer_caller_save_registers and hasattr(
+            self.arch.RegisterType, "callee_saved_registers"
+        ):
+            callee_saved = set(self.arch.RegisterType.callee_saved_registers())
+            self._model._callee_saved_used = {
+                reg: self._NewBoolVar(f"callee_saved_used[{reg}]")
+                for reg in self.arch.RegisterType.callee_saved_registers()
+            }
+
         if self.config.constraints.minimize_register_usage is not None:
             ty = self.config.constraints.minimize_register_usage
             regs = self.arch.RegisterType.list_registers(ty)
             self._model._register_used = {
                 reg: self._NewBoolVar(f"reg_used[{reg}]") for reg in regs
             }
+
+        # Collect registers appearing in the original (pre-renaming) code so
+        # that hints can prefer them.  Input/output pseudo-nodes are excluded
+        # because their registers are fixed by the interface, not by the code.
+        orig_regs = set()
+        for t in self._get_nodes():
+            orig_regs.update(t.inst.args_out)
+            orig_regs.update(t.inst.args_in)
+            orig_regs.update(t.inst.args_in_out)
 
         # Create variables for register renaming
 
@@ -2823,6 +2872,13 @@ class SlothyBase(LockAttributes):
                 if self.config.hints.rename_hint_orig_rename:
                     if arg_out in candidates_restricted:
                         self._AddHint(var_dict[arg_out], True)
+
+                if self.config.constraints.prefer_caller_save_registers:
+                    for out_reg, var in var_dict.items():
+                        if out_reg in orig_regs:
+                            self._AddHint(var, True)
+                        elif out_reg in callee_saved:
+                            self._AddHint(var, False)
 
         # For convenience, also add references to the variables governing the
         # register renaming for input and input/output arguments.
@@ -3141,6 +3197,13 @@ class SlothyBase(LockAttributes):
                     self._AddMaxEquality(self._model._register_used[reg], arr)
                 else:
                     self._Add(self._model._register_used[reg] == False)  # noqa: E712
+
+        for reg, used_var in self._model._callee_saved_used.items():
+            arr = self._model.register_usage_vars.get(reg, [])
+            if len(arr) > 0:
+                self._AddMaxEquality(used_var, arr)
+            else:
+                self._Add(used_var == False)  # noqa: E712
 
         for t in self._get_nodes(allnodes=True):
             can_spill = True
@@ -3976,6 +4039,15 @@ class SlothyBase(LockAttributes):
                     minlist = lst
                 else:
                     maxlist = lst
+
+        # Secondary objective: prefer caller-save registers.
+        # This runs only in the force_objective (step-2 re-optimization) path,
+        # where stalls are already fixed via a hard constraint.
+        if force_objective and self._model._callee_saved_used and len(maxlist) == 0:
+            callee_vars = list(self._model._callee_saved_used.values())
+            if len(minlist) == 0:
+                minlist = callee_vars
+                name = "minimize callee-saved register usage"
 
         self._model.objective_printer = printer
         self._model.objective_vars = objective_vars

--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -386,7 +386,7 @@ class Heuristics:
         # the heuristics for linear optimization.
         if not conf.sw_pipelining.enabled:
             res = Heuristics.linear(body, logger=logger, conf=conf)
-            return [], res.code, [], 0
+            return [], res.code, [], 0, res.clobbered_callee_saved
 
         if conf.sw_pipelining.halving_heuristic:
             return Heuristics._periodic_halving(body, logger, conf)
@@ -413,6 +413,8 @@ class Heuristics:
 
         # Second step: Separately optimize preamble and postamble
 
+        clobbered = result.clobbered_callee_saved
+
         preamble = result.preamble
         if conf.sw_pipelining.optimize_preamble:
             logger.debug("Optimize preamble...")
@@ -425,6 +427,7 @@ class Heuristics:
                 preamble, conf=c, logger=logger.getChild("preamble")
             )
             preamble = res_preamble.code
+            clobbered |= res_preamble.clobbered_callee_saved
 
         postamble = result.postamble
         if conf.sw_pipelining.optimize_postamble:
@@ -436,8 +439,9 @@ class Heuristics:
                 postamble, conf=c, logger=logger.getChild("postamble")
             )
             postamble = res_postamble.code
+            clobbered |= res_postamble.clobbered_callee_saved
 
-        return preamble, kernel, postamble, num_exceptional_iterations
+        return preamble, kernel, postamble, num_exceptional_iterations, clobbered
 
     @staticmethod
     def linear(body: list, logger: any, conf: any) -> any:
@@ -1184,6 +1188,10 @@ class Heuristics:
         # consider [B;A] as a non-periodic snippet, which may still lead to stalls at the
         # loop boundary.
 
+        clobbered = set()
+        if not conf.sw_pipelining.halving_heuristic_split_only:
+            clobbered = res_halving_0.clobbered_callee_saved
+
         if conf.sw_pipelining.halving_heuristic_periodic:
             c = conf.copy()
             c.inputs_are_outputs = True
@@ -1192,9 +1200,11 @@ class Heuristics:
             c.sw_pipelining.allow_pre = False  # - no early instructions
             c.sw_pipelining.allow_post = False  # - no late instructions
             # Just make sure to consider loop boundary
-            kernel = Heuristics.optimize_binsearch(
+            res_periodic = Heuristics.optimize_binsearch(
                 kernel, logger.getChild("periodic heuristic"), conf=c
-            ).code
+            )
+            kernel = res_periodic.code
+            clobbered |= res_periodic.clobbered_callee_saved
         elif not conf.sw_pipelining.halving_heuristic_split_only:
             c = conf.copy()
             c.outputs = new_kernel_deps
@@ -1205,6 +1215,7 @@ class Heuristics:
                 kernel, logger.getChild("heuristic"), conf=c
             )
             final_kernel = res_halving_1.code
+            clobbered |= res_halving_1.clobbered_callee_saved
 
             reordering2 = res_halving_1.reordering_with_bubbles
 
@@ -1252,4 +1263,4 @@ class Heuristics:
             kernel = final_kernel
 
         num_exceptional_iterations = 1
-        return preamble, kernel, postamble, num_exceptional_iterations
+        return preamble, kernel, postamble, num_exceptional_iterations, clobbered

--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -386,7 +386,7 @@ class Heuristics:
         # the heuristics for linear optimization.
         if not conf.sw_pipelining.enabled:
             res = Heuristics.linear(body, logger=logger, conf=conf)
-            return [], res.code, [], 0
+            return [], res.code, [], 0, res.clobbered_callee_saved
 
         if conf.sw_pipelining.halving_heuristic:
             return Heuristics._periodic_halving(body, logger, conf)
@@ -413,6 +413,8 @@ class Heuristics:
 
         # Second step: Separately optimize preamble and postamble
 
+        clobbered = result.clobbered_callee_saved
+
         preamble = result.preamble
         if conf.sw_pipelining.optimize_preamble:
             logger.debug("Optimize preamble...")
@@ -425,6 +427,7 @@ class Heuristics:
                 preamble, conf=c, logger=logger.getChild("preamble")
             )
             preamble = res_preamble.code
+            clobbered |= res_preamble.clobbered_callee_saved
 
         postamble = result.postamble
         if conf.sw_pipelining.optimize_postamble:
@@ -436,8 +439,9 @@ class Heuristics:
                 postamble, conf=c, logger=logger.getChild("postamble")
             )
             postamble = res_postamble.code
+            clobbered |= res_postamble.clobbered_callee_saved
 
-        return preamble, kernel, postamble, num_exceptional_iterations
+        return preamble, kernel, postamble, num_exceptional_iterations, clobbered
 
     @staticmethod
     def linear(body: list, logger: any, conf: any) -> any:
@@ -1191,6 +1195,10 @@ class Heuristics:
         # consider [B;A] as a non-periodic snippet, which may still lead to stalls at the
         # loop boundary.
 
+        clobbered = set()
+        if not conf.sw_pipelining.halving_heuristic_split_only:
+            clobbered = res_halving_0.clobbered_callee_saved
+
         if conf.sw_pipelining.halving_heuristic_periodic:
             c = conf.copy()
             c.inputs_are_outputs = True
@@ -1199,9 +1207,11 @@ class Heuristics:
             c.sw_pipelining.allow_pre = False  # - no early instructions
             c.sw_pipelining.allow_post = False  # - no late instructions
             # Just make sure to consider loop boundary
-            kernel = Heuristics.optimize_binsearch(
+            res_periodic = Heuristics.optimize_binsearch(
                 kernel, logger.getChild("periodic heuristic"), conf=c
-            ).code
+            )
+            kernel = res_periodic.code
+            clobbered |= res_periodic.clobbered_callee_saved
         elif not conf.sw_pipelining.halving_heuristic_split_only:
             c = conf.copy()
             c.outputs = new_kernel_deps
@@ -1212,6 +1222,7 @@ class Heuristics:
                 kernel, logger.getChild("heuristic"), conf=c
             )
             final_kernel = res_halving_1.code
+            clobbered |= res_halving_1.clobbered_callee_saved
 
             reordering2 = res_halving_1.reordering_with_bubbles
 
@@ -1259,4 +1270,4 @@ class Heuristics:
             kernel = final_kernel
 
         num_exceptional_iterations = 1
-        return preamble, kernel, postamble, num_exceptional_iterations
+        return preamble, kernel, postamble, num_exceptional_iterations, clobbered

--- a/slothy/core/slothy.py
+++ b/slothy/core/slothy.py
@@ -116,6 +116,17 @@ class Slothy:
         self.last_result = None
         self.success = None
 
+    def _prepend_clobber_comment(self, code, clobbered, indentation):
+        """Prepend a callee-saved clobber comment to code if the feature is on."""
+        if not (self.config.emit_clobbered_callee_saves_comment and clobbered):
+            return code
+        comment_text = "Clobbered callee-saved registers: " + ", ".join(
+            sorted(clobbered)
+        )
+        clobber_line = SourceLine("").add_comment(comment_text)
+        clobber_line = SourceLine.apply_indentation([clobber_line], indentation)[0]
+        return [clobber_line] + code
+
     def _get_version(self):
         try:
             from importlib.metadata import version
@@ -394,7 +405,11 @@ class Slothy:
                 pre, body, post, "ORIGINAL", indentation
             )
 
-        early, core, late, num_exceptional = Heuristics.periodic(body, logger, c)
+        early, core, late, num_exceptional, clobbered = Heuristics.periodic(
+            body, logger, c
+        )
+
+        core = self._prepend_clobber_comment(core, clobbered, indentation)
 
         if self.config.with_llvm_mca_before is True:
             core = core + orig_stats
@@ -632,9 +647,11 @@ class Slothy:
                 early, body, late, "ORIGINAL", indentation
             )
 
-        preamble_code, kernel_code, postamble_code, num_exceptional = (
+        preamble_code, kernel_code, postamble_code, num_exceptional, clobbered = (
             Heuristics.periodic(body, logger, c)
         )
+
+        kernel_code = self._prepend_clobber_comment(kernel_code, clobbered, indentation)
 
         # Remove branch instructions from preamble and postamble
         postamble_code = [

--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -70,6 +70,11 @@ class RegisterType(Enum):
         return self.name
 
     @staticmethod
+    def callee_saved_registers():
+        # AAPCS32 / Helium calling convention: r4-r11 GPR, q4-q7 MVE
+        return [f"r{i}" for i in range(4, 12)] + [f"q{i}" for i in range(4, 8)]
+
+    @staticmethod
     def is_renamed(ty):
         """Indicate if register type should be subject to renaming"""
         if ty == RegisterType.HINT:

--- a/slothy/targets/riscv/riscv.py
+++ b/slothy/targets/riscv/riscv.py
@@ -92,6 +92,11 @@ class RegisterType(Enum):
     list_registers = staticmethod(_list_registers)
 
     @staticmethod
+    def callee_saved_registers():
+        # RISC-V calling convention: s0-s11 = x8, x9, x18-x27
+        return ["x8", "x9"] + [f"x{i}" for i in range(18, 28)]
+
+    @staticmethod
     def find_type(r):
         """Find type of architectural register"""
 

--- a/tests/naive/aarch64/_test.py
+++ b/tests/naive/aarch64/_test.py
@@ -25,6 +25,8 @@
 # Author: Amin Abdulrahman <amin@abdulrahman.de>
 #
 
+import re
+
 from common.OptimizationRunner import OptimizationRunner
 import slothy.targets.aarch64.aarch64_neon as AArch64_Neon
 import slothy.targets.aarch64.cortex_a55 as Target_CortexA55
@@ -472,6 +474,191 @@ class AArch64Directives(OptimizationRunner):
         slothy.optimize(start="start_irp_single", end="end_irp_single")  # 1 instruction
 
 
+class AArch64PreferCallerSave(OptimizationRunner):
+    """Verify that prefer_caller_save_registers=True does not introduce
+    callee-saved NEON registers (v8-v15) when the input uses only caller-save
+    registers (v0-v7).  The snippet contains enough instructions for SLOTHY
+    to consider register renaming, so the absence of callee-saved registers in
+    the output is a meaningful behavioural check."""
+
+    def __init__(self, arch=AArch64_Neon, target=Target_CortexA55):
+        super().__init__(
+            "aarch64_prefer_caller_save",
+            rename=True,
+            arch=arch,
+            target=target,
+            base_dir="tests",
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 32
+        slothy.config.outputs = ["v0", "v1", "v5", "v7"]
+        slothy.config.constraints.prefer_caller_save_registers = True
+        slothy.optimize(start="start", end="end")
+
+        callee_saved_neon = {f"v{i}" for i in range(8, 16)}
+        source_text = "\n".join(
+            line.to_string(comments=False, tags=False)
+            for line in slothy.source
+            if line.text
+        )
+        found_vregs = {f"v{n}" for n in re.findall(r"\bv(\d+)", source_text)}
+        introduced = callee_saved_neon & found_vregs
+        if introduced:
+            raise Exception(
+                f"prefer_caller_save_registers=True introduced callee-saved "
+                f"NEON register(s): {', '.join(sorted(introduced))}"
+            )
+
+
+class AArch64PreferCallerSaveForced(OptimizationRunner):
+    """Verify that prefer_caller_save_registers=True still produces correct
+    code when callee-saved registers are unavoidable.
+
+    Three independent NTT butterflies all reuse v4, v5 as temporaries.
+    v7 and v16-v31 are reserved, leaving only v4 and v5 as free caller-save
+    scratch space.  Overlapping any two butterflies for ILP needs four
+    simultaneous temporaries, which exhausts the caller-save pool and forces
+    SLOTHY to introduce at least one callee-saved register (v8-v15).
+
+    The test asserts:
+      - the selftest passes (functional correctness is preserved), and
+      - at least one v8-v15 register appears in the output (confirming that
+        callee-saved registers were actually introduced when necessary)."""
+
+    def __init__(self, arch=AArch64_Neon, target=Target_CortexA55):
+        super().__init__(
+            "aarch64_prefer_caller_save_forced",
+            rename=True,
+            arch=arch,
+            target=target,
+            base_dir="tests",
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 32
+        slothy.config.outputs = ["v0", "v1", "v5", "v6"]
+        slothy.config.constraints.prefer_caller_save_registers = True
+        slothy.config.reserved_regs = ["v7"] + [f"v{i}" for i in range(16, 32)]
+        slothy.optimize(start="start", end="end")
+
+        source_text = "\n".join(
+            line.to_string(comments=False, tags=False)
+            for line in slothy.source
+            if line.text
+        )
+        found_callee_saved = {
+            f"v{n}" for n in re.findall(r"\bv(\d+)", source_text) if 8 <= int(n) <= 15
+        }
+        if not found_callee_saved:
+            raise Exception(
+                "Expected SLOTHY to introduce callee-saved NEON registers "
+                "(v8-v15) when caller-save scratch space is exhausted, but "
+                "none were found in the output"
+            )
+
+
+class AArch64ClobberComment(OptimizationRunner):
+    """Verify that emit_clobbered_callee_saves_comment=True prepends a comment
+    listing the callee-saved registers that the snippet clobbers.  The input
+    explicitly uses v8, v9 (callee-saved NEON) and x19 (callee-saved GPR),
+    so all three must appear in the comment.
+
+    Renaming is disabled so the output registers match the input exactly and
+    the assertion is not sensitive to which physical register SLOTHY happens
+    to allocate."""
+
+    def __init__(self, arch=AArch64_Neon, target=Target_CortexA55):
+        super().__init__(
+            "aarch64_clobber_comment",
+            rename=True,
+            arch=arch,
+            target=target,
+            base_dir="tests",
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 32
+        slothy.config.constraints.allow_renaming = False
+        slothy.config.outputs = ["v8", "x19"]
+        slothy.config.emit_clobbered_callee_saves_comment = True
+        slothy.optimize(start="start", end="end")
+
+        source_text = "\n".join(line.to_string() for line in slothy.source)
+        if "Clobbered callee-saved registers:" not in source_text:
+            raise Exception(
+                "emit_clobbered_callee_saves_comment=True did not produce "
+                "a clobber comment in the output"
+            )
+        # All three callee-saved registers used in the snippet must be listed.
+        for reg in ("v8", "v9", "x19"):
+            # The comment line contains the register names separated by ", "
+            comment_line = next(
+                (
+                    line.to_string()
+                    for line in slothy.source
+                    if "Clobbered callee-saved registers:" in line.to_string()
+                ),
+                "",
+            )
+            if reg not in comment_line:
+                raise Exception(
+                    f"Clobber comment is missing callee-saved register {reg}. "
+                    f"Full comment line: {comment_line!r}"
+                )
+
+
+class AArch64ClobberCommentSWP(OptimizationRunner):
+    """Verify that emit_clobbered_callee_saves_comment works through the SW
+    pipelining code path in Heuristics.periodic().
+
+    The loop uses callee-saved NEON registers v8, v9, v12.  Renaming is
+    disabled so the output registers are fixed.  minimize_overlapping is
+    disabled so the solver is free to move instructions across iteration
+    boundaries, producing non-empty preamble and postamble; the clobbered set
+    must be accumulated across kernel + preamble + postamble and appear in the
+    comment prepended to kernel_code."""
+
+    def __init__(self, arch=AArch64_Neon, target=Target_CortexA55):
+        super().__init__(
+            "aarch64_clobber_comment_swp",
+            rename=True,
+            arch=arch,
+            target=target,
+            base_dir="tests",
+        )
+
+    def core(self, slothy):
+        slothy.config.variable_size = True
+        slothy.config.constraints.stalls_first_attempt = 32
+        slothy.config.constraints.allow_renaming = False
+        slothy.config.inputs_are_outputs = True
+        slothy.config.sw_pipelining.enabled = True
+        slothy.config.sw_pipelining.minimize_overlapping = False
+        slothy.config.emit_clobbered_callee_saves_comment = True
+        slothy.optimize_loop("start")
+
+        source_text = "\n".join(line.to_string() for line in slothy.source)
+        if "Clobbered callee-saved registers:" not in source_text:
+            raise Exception(
+                "emit_clobbered_callee_saves_comment=True did not produce "
+                "a clobber comment through the SW pipelining code path"
+            )
+        comment_line = next(
+            line.to_string()
+            for line in slothy.source
+            if "Clobbered callee-saved registers:" in line.to_string()
+        )
+        for reg in ("v8", "v9"):
+            if reg not in comment_line:
+                raise Exception(
+                    f"Clobber comment missing {reg}. Full line: {comment_line!r}"
+                )
+
+
 test_instances = [
     Instructions(),
     Instructions(target=Target_CortexA72),
@@ -500,4 +687,8 @@ test_instances = [
     AArch64SelftestAddr(),
     AArch64SelftestInitialRegs(),
     AArch64Directives(),
+    AArch64PreferCallerSave(),
+    AArch64PreferCallerSaveForced(),
+    AArch64ClobberComment(),
+    AArch64ClobberCommentSWP(),
 ]

--- a/tests/naive/aarch64/aarch64_clobber_comment.s
+++ b/tests/naive/aarch64/aarch64_clobber_comment.s
@@ -1,0 +1,13 @@
+// Small snippet that deliberately uses callee-saved registers (v8, v9, x19).
+// Renaming is disabled in the test so the output preserves these exact register
+// names; with emit_clobbered_callee_saves_comment=True SLOTHY must prepend a
+// comment listing them.
+start:
+    ldr      q8,  [x0]
+    ldr      q9,  [x0, #16]
+    ldr      x19, [x0, #32]
+    add      v8.4s, v8.4s, v9.4s
+    add      x19, x19, x19
+    str      q8,  [x1]
+    str      x19, [x1, #16]
+end:

--- a/tests/naive/aarch64/aarch64_clobber_comment_swp.s
+++ b/tests/naive/aarch64/aarch64_clobber_comment_swp.s
@@ -1,0 +1,25 @@
+// NTT butterfly loop using callee-saved NEON regs v8-v12.  The load-use
+// latency between ldr and mul/sqrdmulh is long enough on Cortex-A55 that SW
+// pipelining moves the loads into the preamble and the stores into the
+// postamble, giving non-empty preamble and postamble.  This exercises the
+// clobbered-set accumulation across all three parts in Heuristics.periodic().
+
+count .req x3
+
+mov      count, #16
+start:
+    ldr      q8,  [x0, #0*16]
+    ldr      q9,  [x0, #1*16]
+
+    mul      v12.8h, v9.8h,  v0.h[0]
+    sqrdmulh v9.8h,  v9.8h,  v0.h[1]
+    mls      v12.8h, v9.8h,  v1.h[0]
+    sub      v9.8h,  v8.8h,  v12.8h
+    add      v8.8h,  v8.8h,  v12.8h
+
+    str      q8,  [x0, #0*16]
+    str      q9,  [x0, #1*16]
+    add      x0,  x0,  #2*16
+
+    subs     count, count, #1
+    cbnz     count, start

--- a/tests/naive/aarch64/aarch64_prefer_caller_save.s
+++ b/tests/naive/aarch64/aarch64_prefer_caller_save.s
@@ -1,0 +1,15 @@
+// Two independent NTT butterflies using only caller-save NEON registers (v0-v7).
+// With prefer_caller_save_registers=True SLOTHY should not introduce any
+// callee-saved register (v8-v15) when renaming the temporaries v4/v5/v6/v7.
+start:
+    mul      v4.8h, v0.8h, v2.h[0]
+    sqrdmulh v5.8h, v0.8h, v2.h[1]
+    mls      v4.8h, v5.8h, v3.h[0]
+    sub      v5.8h, v0.8h, v4.8h
+    add      v0.8h, v0.8h, v4.8h
+    mul      v6.8h, v1.8h, v2.h[0]
+    sqrdmulh v7.8h, v1.8h, v2.h[1]
+    mls      v6.8h, v7.8h, v3.h[0]
+    sub      v7.8h, v1.8h, v6.8h
+    add      v1.8h, v1.8h, v6.8h
+end:

--- a/tests/naive/aarch64/aarch64_prefer_caller_save_forced.s
+++ b/tests/naive/aarch64/aarch64_prefer_caller_save_forced.s
@@ -1,0 +1,25 @@
+// Three independent NTT butterflies that all reuse v4, v5 as temporaries
+// (WAW hazard between butterflies).  Butterflies 1 and 2 only produce their
+// upper outputs (v0, v1); butterfly 3 produces both outputs (v6 upper, v5
+// lower).  v0-v3 are inputs/twiddles.
+//
+// v7 and v16-v31 are reserved in the test config, so the only free
+// caller-save scratch registers are v4 and v5.  Overlapping any two
+// butterflies for ILP requires four simultaneous temporaries, exhausting the
+// two free caller-save slots and forcing SLOTHY to introduce at least one
+// callee-saved register (v8-v15) even with prefer_caller_save_registers=True.
+start:
+    mul      v4.8h, v0.8h, v2.h[0]
+    sqrdmulh v5.8h, v0.8h, v2.h[1]
+    mls      v4.8h, v5.8h, v3.h[0]
+    add      v0.8h, v0.8h, v4.8h
+    mul      v4.8h, v1.8h, v2.h[0]
+    sqrdmulh v5.8h, v1.8h, v2.h[1]
+    mls      v4.8h, v5.8h, v3.h[0]
+    add      v1.8h, v1.8h, v4.8h
+    mul      v4.8h, v6.8h, v2.h[0]
+    sqrdmulh v5.8h, v6.8h, v2.h[1]
+    mls      v4.8h, v5.8h, v3.h[0]
+    sub      v5.8h, v6.8h, v4.8h
+    add      v6.8h, v6.8h, v4.8h
+end:


### PR DESCRIPTION
* Add `callee_saved_registers()` to Arm v8.1-M/Helium and RISC-V ISA models
* Add `config.constraints.prefer_caller_save_registers`: biases allocation toward input registers and away from callee-saved ones via CP-SAT hints and a secondary minimisation objective (never sacrifices stall counts)
* Add `config.emit_clobbered_callee_saves_comment` (default True): prepends a comment listing clobbered callee-saved registers to the output
* Accumulate clobber set across preamble, kernel, and postamble in `Heuristics.periodic`; store on `Result`
* Add four AArch64 naive tests covering the new features including a forced callee-save allocation case and a SW-pipelining path