### PR TITLE
Update ortools to 9.15.6755

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "ortools==9.7.2996; python_version < '3.12'",
-    # ortools depends on pandas, but 9.7 does not specify it as dependency
-    "pandas>=2.0.3; python_version < '3.12'",
-    # ortools 9.7 requires protobuf<=6.31.1
-    "protobuf<=6.31.1; python_version < '3.12'",
-    "ortools==9.15.6755; python_version >= '3.12'",
+    "ortools==9.15.6755",
     "sympy==1.14.0",
     "unicorn==2.1.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
-ortools==9.7.2996 ; python_version < "3.12"
-ortools==9.15.6755 ; python_version >= "3.12"
-# ortools 9.7 requires protobuf<=6.31.1
-protobuf<=6.31.1 ; python_version < "3.12"
-# ortools depends on pandas, but 9.7 does not specify it as dependency
-pandas>=2.0.3 ; python_version < "3.12"
+ortools==9.15.6755
 sympy==1.14.0
 unicorn==2.1.4
 black==26.3.1

--- a/slothy/core/core.py
+++ b/slothy/core/core.py
@@ -4006,6 +4006,8 @@ class SlothyBase(LockAttributes):
         self._model.cp_model = cp_model.CpModel()
         self._model.cp_solver = cp_model.CpSolver()
         self._model.cp_solver.random_seed = self.config.solver_random_seed
+        # feasibility_jump (default-on since 9.8) hurts performance on SLOTHY models.
+        self._model.cp_solver.parameters.use_feasibility_jump = False
 
     def _NewIntVar(self, minval, maxval, name=""):
         r = self._model.cp_model.NewIntVar(minval, maxval, name)


### PR DESCRIPTION
Add Python 3.14 to test matrix and classifiers. Remove version-specific ortools dependencies and workarounds for older versions.

Disable OR-Tools feasibility_jump - this is enabled by default since OR-Tools 9.8, but causes a large performance regression on SLOTHY's scheduling-heavy models. Disabling it restores 9.7 behaviour.