### PR TITLE
AArch64: add CRC32/CRC32C instruction family to (A55, A72, N1) models

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -128,9 +128,9 @@ arch_name = "Arm_AArch64"
 
 llvm_mca_arch = "aarch64"
 llvm_mc_arch = "aarch64"
-# Always add aes flag for llvm-mc assembly -- assuming that the user will not
-# use aes instructions on CPUs that do not support it
-llvm_mc_attr = "aes"
+# Enable llvm-mc feature flags for instruction extensions used in the model.
+# Add flags here as new instruction families are added.
+llvm_mc_attr = "aes,crc"
 
 unicorn_arch = UC_ARCH_ARM64
 unicorn_mode = UC_MODE_ARM
@@ -3175,6 +3175,58 @@ class msub_xform(AArch64Multiply):
     pattern = "msub <Xd>, <Xacc>, <Xa>, <Xb>"
     inputs = ["Xacc", "Xa", "Xb"]
     outputs = ["Xd"]
+
+
+class AArch64CRC32(AArch64Instruction):
+    pass
+
+
+class crc32b(AArch64CRC32):
+    pattern = "crc32b <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32h(AArch64CRC32):
+    pattern = "crc32h <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32w(AArch64CRC32):
+    pattern = "crc32w <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32x(AArch64CRC32):
+    pattern = "crc32x <Wd>, <Wa>, <Xb>"
+    inputs = ["Wa", "Xb"]
+    outputs = ["Wd"]
+
+
+class crc32cb(AArch64CRC32):
+    pattern = "crc32cb <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32ch(AArch64CRC32):
+    pattern = "crc32ch <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32cw(AArch64CRC32):
+    pattern = "crc32cw <Wd>, <Wa>, <Wb>"
+    inputs = ["Wa", "Wb"]
+    outputs = ["Wd"]
+
+
+class crc32cx(AArch64CRC32):
+    pattern = "crc32cx <Wd>, <Wa>, <Xb>"
+    inputs = ["Wa", "Xb"]
+    outputs = ["Wd"]
 
 
 class and_imm_wform(AArch64Instruction):

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -181,6 +181,14 @@ from slothy.targets.aarch64.aarch64_neon import (
     fmov_s_form,  # from double/single to gen reg
     cmp,
     vdup_w,
+    crc32b,
+    crc32h,
+    crc32w,
+    crc32x,
+    crc32cb,
+    crc32ch,
+    crc32cw,
+    crc32cx,
 )
 
 issue_rate = 2
@@ -448,6 +456,16 @@ execution_units = {
     # is not modeled
     AESInstruction: [[ExecutionUnit.VEC0, ExecutionUnit.VEC1]],
     csel: ExecutionUnit.SCALAR(),
+    (
+        crc32b,
+        crc32h,
+        crc32w,
+        crc32x,
+        crc32cb,
+        crc32ch,
+        crc32cw,
+        crc32cx,
+    ): ExecutionUnit.SCALAR(),
 }
 
 inverse_throughput = {
@@ -544,6 +562,7 @@ inverse_throughput = {
     fmov_s_form: 1,  # from double/single to gen reg
     vdup_w: 1,
     (sxtb, uxtb): 1,
+    (crc32b, crc32h, crc32w, crc32x, crc32cb, crc32ch, crc32cw, crc32cx): 1,
 }
 
 default_latencies = {
@@ -652,6 +671,8 @@ default_latencies = {
     AESInstruction: 2,
     fmov_s_form: 1,  # from double/single to gen reg
     (sxtb, uxtb): 1,
+    (crc32b, crc32h, crc32x, crc32cb, crc32ch, crc32cx): 2,
+    (crc32w, crc32cw): 1,
 }
 
 

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -125,6 +125,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     cmp_imm,
     csel,
     q_ldp_with_inc,
+    AArch64CRC32,
 )
 
 # From the A72 SWOG, Section "4.1 Dispatch Constraints"
@@ -145,8 +146,7 @@ class ExecutionUnit(Enum):
     STORE1 = auto()
     INT0 = auto()
     INT1 = auto()
-    MINT0 = auto()
-    MINT1 = auto()
+    SCALAR_MINT = auto()
     ASIMD0 = auto()
     ASIMD1 = auto()
 
@@ -171,7 +171,7 @@ class ExecutionUnit(Enum):
 
     @classmethod
     def MINT(cls):
-        return [ExecutionUnit.MINT0, ExecutionUnit.MINT1]
+        return [ExecutionUnit.SCALAR_MINT]
 
     @classmethod
     def SCALAR(cls):
@@ -264,6 +264,7 @@ execution_units = {
     Ldp_W: ExecutionUnit.LOAD(),
     q_ldp_with_inc: ExecutionUnit.LOAD(),
     Stp_W: ExecutionUnit.STORE(),
+    AArch64CRC32: ExecutionUnit.MINT(),
 }
 
 inverse_throughput = {
@@ -322,6 +323,7 @@ inverse_throughput = {
     movk_imm_lsl: 1,
     Ldp_W: 1,
     Stp_W: 1,
+    AArch64CRC32: 1,
 }
 
 # REVISIT
@@ -389,6 +391,7 @@ default_latencies = {
     movk_imm_lsl: 1,
     Ldp_W: 4,
     Stp_W: 1,
+    AArch64CRC32: 2,
 }
 
 
@@ -426,6 +429,13 @@ def get_latency(src, out_idx, dst):
         instclass_src in all_subclass_leaves(Vmlal)
         and instclass_dst in all_subclass_leaves(Vmlal)
         and src.args_in_out[0] == dst.args_in_out[0]
+    ):
+        return 1
+    # Fast CRC32 chain forwarding (A72 SWOG)
+    if (
+        instclass_src in all_subclass_leaves(AArch64CRC32)
+        and instclass_dst in all_subclass_leaves(AArch64CRC32)
+        and src.args_out[0] == dst.args_in[0]
     ):
         return 1
 

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -72,6 +72,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     AArch64ShiftedArithmetic,
     AArch64HighMultiply,
     AArch64Multiply,
+    AArch64CRC32,
     VecToGprMov,
     St3,
     St4,
@@ -251,6 +252,7 @@ execution_units = {
     fmov_s_form: ExecutionUnit.V1(),  # from vec to gen reg
     umull_wform: ExecutionUnit.M(),
     (AArch64HighMultiply, AArch64Multiply): ExecutionUnit.M(),
+    AArch64CRC32: ExecutionUnit.M(),
     (vdup, vdup_w): ExecutionUnit.M(),
     # 8B/8H occupies both V0, V1
     vuaddlv_sform: [[ExecutionUnit.VEC0, ExecutionUnit.VEC1]],
@@ -309,6 +311,7 @@ inverse_throughput = {
     fmov_s_form: 1,  # from vec to gen reg
     (AArch64HighMultiply): 4,
     (AArch64Multiply): 3,
+    AArch64CRC32: 1,
     (vdup, vdup_w): 1,
     umull_wform: 1,
     vuaddlv_sform: 1,  # 8B/8H
@@ -374,6 +377,7 @@ default_latencies = {
     fmov_s_form: 2,  # from vec to gen reg
     AArch64HighMultiply: 5,
     AArch64Multiply: 4,
+    AArch64CRC32: 2,
     (vdup, vdup_w): 3,
     umull_wform: 2,
     vtbl: 2,
@@ -423,6 +427,13 @@ def get_latency(src, out_idx, dst):
         instclass_src in all_subclass_leaves(Vmlal)
         and instclass_dst in all_subclass_leaves(Vmlal)
         and src.args_in_out[0] == dst.args_in_out[0]
+    ):
+        return 1
+    # Fast CRC32 chain forwarding (SWOG, section 3.21 CRC note 1)
+    if (
+        instclass_src in all_subclass_leaves(AArch64CRC32)
+        and instclass_dst in all_subclass_leaves(AArch64CRC32)
+        and src.args_out[0] == dst.args_in[0]
     ):
         return 1
 

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -207,4 +207,12 @@ ld3 {v2.4s, v3.4s, v4.4s}, [x17], #48
 st3 {v5.4s, v6.4s, v7.4s}, [x18], #48
 ld2 {v8.4s, v9.4s}, [x19], #32
 st2 {v10.4s, v11.4s}, [x20], #32
+crc32b w5, w5, w7
+crc32h w5, w5, w7
+crc32w w5, w5, w7
+crc32x w5, w5, x8
+crc32cb w6, w6, w7
+crc32ch w6, w6, w7
+crc32cw w6, w6, w7
+crc32cx w6, w6, x8
 end:


### PR DESCRIPTION
Add all eight scalar CRC32/CRC32C variants (B/H/W/X) to the AArch64 architecture model and Neoverse N1 microarchitecture model.

Scheduling data (Neoverse N1 Software Optimization Guide, section 3.21):
- Execution unit: M
- Inverse throughput: 1
- Latency: 2 (1 with CRC->CRC chain forwarding, see Note 1 in SWOG section 3.21)

Also adds crc to llvm_mc_attr so llvm-mc can assemble CRC32 instructions during selftest.