### PR TITLE
AArch64: add fmov <Xd>, <Dn> support to A55, A72, and N1 models

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -4043,6 +4043,12 @@ class fmov_s_form(Fmov):
     outputs = ["Wd"]
 
 
+class fmov_d_form(Fmov):
+    pattern = "fmov <Xd>, <Da>"
+    inputs = ["Da"]
+    outputs = ["Xd"]
+
+
 class fmov_0(Fmov):
     pattern = "fmov <Dd>, <Xa>"
     inputs = ["Xa"]

--- a/slothy/targets/aarch64/cortex_a55.py
+++ b/slothy/targets/aarch64/cortex_a55.py
@@ -179,6 +179,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     sub_imm,
     vuaddlv_sform,
     fmov_s_form,  # from double/single to gen reg
+    fmov_d_form,  # from double/single to gen reg (64-bit)
     cmp,
     vdup_w,
     crc32b,
@@ -345,6 +346,7 @@ execution_units = {
         b_ldr_stack_with_inc,
         d_ldr_stack_with_inc,
         fmov_s_form,  # from double/single to gen reg
+        fmov_d_form,  # from double/single to gen reg (64-bit)
         vdup_w,
     ): [
         ExecutionUnit.VEC0,
@@ -560,6 +562,7 @@ inverse_throughput = {
     AArch64ConditionalCompare: 1,
     AESInstruction: 1,
     fmov_s_form: 1,  # from double/single to gen reg
+    fmov_d_form: 1,  # from double/single to gen reg (64-bit)
     vdup_w: 1,
     (sxtb, uxtb): 1,
     (crc32b, crc32h, crc32w, crc32x, crc32cb, crc32ch, crc32cw, crc32cx): 1,
@@ -670,6 +673,7 @@ default_latencies = {
     # is not modeled
     AESInstruction: 2,
     fmov_s_form: 1,  # from double/single to gen reg
+    fmov_d_form: 1,  # from double/single to gen reg (64-bit)
     (sxtb, uxtb): 1,
     (crc32b, crc32h, crc32x, crc32cb, crc32ch, crc32cx): 2,
     (crc32w, crc32cw): 1,

--- a/slothy/targets/aarch64/cortex_a72_frontend.py
+++ b/slothy/targets/aarch64/cortex_a72_frontend.py
@@ -107,6 +107,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     sub_imm,
     vuaddlv_sform,
     fmov_s_form,  # from vec to gen reg
+    fmov_d_form,  # from vec to gen reg (64-bit)
     fcsel,
     eor_shifted,
     bic_shifted,
@@ -255,6 +256,7 @@ execution_units = {
     ],
     AESInstruction: [ExecutionUnit.ASIMD0],
     fmov_s_form: ExecutionUnit.LOAD(),  # from vec to gen reg
+    fmov_d_form: ExecutionUnit.LOAD(),  # from vec to gen reg (64-bit)
     eor_shifted: ExecutionUnit.SCALAR(),
     bic_shifted: ExecutionUnit.SCALAR(),
     lsr_imm: ExecutionUnit.INT(),
@@ -313,6 +315,7 @@ inverse_throughput = {
     (sub_imm, cmp, cmp_imm): 1,
     vuaddlv_sform: 1,
     fmov_s_form: 1,  # from vec to gen reg
+    fmov_d_form: 1,  # from vec to gen reg (64-bit)
     eor_shifted: 1,
     bic_shifted: 1,
     vdup_w: 1,
@@ -381,6 +384,7 @@ default_latencies = {
     (sub_imm, cmp, cmp_imm): 1,
     vuaddlv_sform: 6,  # 8B/8H
     fmov_s_form: 5,  # from vec to gen reg
+    fmov_d_form: 5,  # from vec to gen reg (64-bit)
     eor_shifted: 2,
     bic_shifted: 2,
     vdup_w: 8,

--- a/slothy/targets/aarch64/neoverse_n1_experimental.py
+++ b/slothy/targets/aarch64/neoverse_n1_experimental.py
@@ -97,6 +97,7 @@ from slothy.targets.aarch64.aarch64_neon import (
     vtbl,
     vuaddlv_sform,
     fmov_s_form,  # from vec to gen reg
+    fmov_d_form,  # from vec to gen reg (64-bit)
     fmov_0,
     fmov_0_force_output,
     fmov_1,
@@ -250,6 +251,7 @@ execution_units = {
         fmov_1_force_output,
     ): ExecutionUnit.M(),
     fmov_s_form: ExecutionUnit.V1(),  # from vec to gen reg
+    fmov_d_form: ExecutionUnit.V1(),  # from vec to gen reg (64-bit)
     umull_wform: ExecutionUnit.M(),
     (AArch64HighMultiply, AArch64Multiply): ExecutionUnit.M(),
     AArch64CRC32: ExecutionUnit.M(),
@@ -309,6 +311,7 @@ inverse_throughput = {
         fmov_1_force_output,
     ): 1,
     fmov_s_form: 1,  # from vec to gen reg
+    fmov_d_form: 1,  # from vec to gen reg (64-bit)
     (AArch64HighMultiply): 4,
     (AArch64Multiply): 3,
     AArch64CRC32: 1,
@@ -375,6 +378,7 @@ default_latencies = {
         fmov_1_force_output,
     ): 3,
     fmov_s_form: 2,  # from vec to gen reg
+    fmov_d_form: 2,  # from vec to gen reg (64-bit)
     AArch64HighMultiply: 5,
     AArch64Multiply: 4,
     AArch64CRC32: 2,

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -215,4 +215,5 @@ crc32cb w6, w6, w7
 crc32ch w6, w6, w7
 crc32cw w6, w6, w7
 crc32cx w6, w6, x8
+fmov x5, d7
 end:


### PR DESCRIPTION
  Add the 64-bit FP/SIMD scalar to GPR transfer (`fmov Xd, Dn`) to the architecture model and all three microarchitecture models.
  
  ### Scheduling data
  
  | Target | Unit | Lat | Tput | SWOG row | LLVM confirmation |
  |--------|------|-----|------|----------|-------------------|
  | N1 | V1 | 2 | 1 | "FP transfer, from vec to gen reg" | `WriteFCopy = N1Write_2c_1V1` |
  | A72 | L | 5 | 1 | "FP transfer, from vec to gen reg" | `WriteFCopy = A57Write_5cyc_1L` |
  | A55 | VEC | 1 | 1 | "FP transfer, from double/single to gen reg" | `WriteFCopy = CortexA55UnitFPALU` |
  
  ### Notes
  - `Dn` is a "SIMD and floating-point scalar register" (Arm ARM DDI0487G, Table C1-3). The SWOGs don't explicitly list which assembly forms fall under each row, but LLVM maps `FMOVDXr` to `WriteFCopy` on all three targets, matching the "FP transfer" rows above.
  - A55 SWOG throughput is listed as 2 (across 2 pipes); SLOTHY models inverse throughput per execution unit, so this becomes 1.
  
  Also adds the instruction to the shared `instructions.s` test.