### PR TITLE
fix: don't discard optimized code when post-split perf estimate fails

### DIFF
--- a/slothy/core/heuristics.py
+++ b/slothy/core/heuristics.py
@@ -961,14 +961,21 @@ class Heuristics:
             conf2.constraints.allow_renaming = False
             conf2.constraints.allow_reordering = False
             conf2.variable_size = True
-            stall_res = Heuristics.optimize_binsearch(
-                res.code, logger.getChild("split_estimtate_perf"), conf2
-            )
-            if stall_res.success is False:
-                log.error(
-                    "Stall-estimate for final code after split heuristic failed"
-                    " -- should not happen? Maybe increase timeout?"
-                    " Just returning the result without stall-estimate."
+            conf2.timeout = None
+            conf2.retry_timeout = None
+            stall_res = None
+            try:
+                stall_res = Heuristics.optimize_binsearch(
+                    res.code, logger.getChild("split_estimate_perf"), conf2
+                )
+            except SlothyException:
+                pass
+
+            if stall_res is None or stall_res.success is False:
+                log.warning(
+                    "Stall-estimate for final code after split heuristic"
+                    " failed -- returning the optimized result without"
+                    " stall-estimate."
                 )
             else:
                 res2 = Result(conf2)


### PR DESCRIPTION
The performance estimate after the split heuristic runs another binary
search (`optimize_binsearch`), which raises `SlothyException` on failure
rather than returning `success=False`. That exception propagated up and
discarded the already-optimized code. It also inherited the optimization
timeout, so a too-short timeout would abort it.

Catch the exception (warn and keep the optimized code without a stall
estimate) and disable the timeout for the estimate, since it only inserts
stalls into the already-fixed ordering.

Closes #96 @dop-amin 