### PR TITLE
AArch64: Add support for vorr with immediate

### DIFF
--- a/slothy/targets/aarch64/aarch64_neon.py
+++ b/slothy/targets/aarch64/aarch64_neon.py
@@ -3607,6 +3607,11 @@ class vorr(AArch64NeonLogical):
     outputs = ["Vd"]
 
 
+class vorr_imm(AArch64NeonLogical):
+    pattern = "orr <Vda>.<dt>, <imm>"
+    in_outs = ["Vda"]
+
+
 class vorn(AArch64NeonLogical):
     pattern = "orn <Vd>.<dt>, <Va>.<dt>, <Vb>.<dt>"
     inputs = ["Va", "Vb"]

--- a/tests/naive/aarch64/instructions.s
+++ b/tests/naive/aarch64/instructions.s
@@ -44,6 +44,7 @@ bic v0.8h, 0xf0, lsl #8
 
 mvn v22.16b, v23.16b
 orr v24.16b, v25.16b, v26.16b
+orr v0.4s, #1
 orn v27.16b, v28.16b, v29.16b
 eor v30.16b, v31.16b, v0.16b
 ext v0.16b, v1.16b, v2.16b, #8


### PR DESCRIPTION
AArch64: add support for NEON orr with immediate

Add a vorr_imm instruction class matching the two-operand `orr <Vd>.<dt>, <imm>`
form, modeled as a read-modify-write on the destination register like the
existing vbic_imm_shifted. Extend the AArch64 instructions smoke test to cover
the new form.

- Resolves #455