### PR TITLE
arm_v81m: model Cortex-M55 shifted operand latency

### DIFF
--- a/slothy/targets/arm_v81m/arch_v81m.py
+++ b/slothy/targets/arm_v81m/arch_v81m.py
@@ -1000,16 +1000,49 @@ class restored(Instruction):
         return obj
 
 
+class ShiftedOperandInstruction(MVEInstruction):
+    """Instruction with a flexible shifted-register Operand2."""
+
+    shifted_operand = "Rm"
+
+    @classmethod
+    def make(cls, src):
+        obj = MVEInstruction.build(cls, src)
+        obj.barrel = obj.barrel.strip()
+        return obj
+
+    @property
+    def shifted_register(self):
+        """Return the register consumed by the inline barrel shifter."""
+        for index, (operand, register_type) in enumerate(self.pattern_inputs):
+            if operand == self.shifted_operand:
+                if register_type != RegisterType.GPR:
+                    raise FatalParsingException(
+                        f"Shifted operand {operand} is not a GPR in {self.pattern}"
+                    )
+                return self.args_in[index]
+        raise FatalParsingException(
+            f"No shifted operand {self.shifted_operand} in {self.pattern}"
+        )
+
+
 class add(MVEInstruction):
     pattern = "add <Rd>, <Rn>, <Rm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
 
 
-class add_shifted(MVEInstruction):
-    pattern = "add <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+class add_shifted(ShiftedOperandInstruction):
+    pattern = "add<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
+
+
+class adc_shifted(ShiftedOperandInstruction):
+    pattern = "adc<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    outputs = ["Rd"]
+    dependsOnFlags = True
 
 
 class log_and(MVEInstruction):
@@ -1018,8 +1051,8 @@ class log_and(MVEInstruction):
     outputs = ["Rd"]
 
 
-class log_and_shifted(MVEInstruction):
-    pattern = "and <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+class log_and_shifted(ShiftedOperandInstruction):
+    pattern = "and<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
 
@@ -1036,8 +1069,14 @@ class orr(MVEInstruction):
     outputs = ["Rd"]
 
 
-class orr_shifted(MVEInstruction):
-    pattern = "orr <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+class orr_shifted(ShiftedOperandInstruction):
+    pattern = "orr<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    outputs = ["Rd"]
+
+
+class orn_shifted(ShiftedOperandInstruction):
+    pattern = "orn<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
 
@@ -1048,7 +1087,7 @@ class eor(MVEInstruction):
     outputs = ["Rd"]
 
 
-class eor_shifted(MVEInstruction):
+class eor_shifted(ShiftedOperandInstruction):
     pattern = "eor<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
@@ -1060,10 +1099,59 @@ class bic(MVEInstruction):
     outputs = ["Rd"]
 
 
-class bic_shifted(MVEInstruction):
-    pattern = "bic <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+class bic_shifted(ShiftedOperandInstruction):
+    pattern = "bic<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
     inputs = ["Rn", "Rm"]
     outputs = ["Rd"]
+
+
+class cmn_shifted(ShiftedOperandInstruction):
+    pattern = "cmn<width> <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    modifiesFlags = True
+
+
+class cmp_shifted(ShiftedOperandInstruction):
+    pattern = "cmp<width> <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    modifiesFlags = True
+
+
+class mvn_shifted(ShiftedOperandInstruction):
+    pattern = "mvn<width> <Rd>, <Rm>, <barrel> <imm>"
+    inputs = ["Rm"]
+    outputs = ["Rd"]
+
+
+class rsb_shifted(ShiftedOperandInstruction):
+    pattern = "rsb<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    outputs = ["Rd"]
+
+
+class sbc_shifted(ShiftedOperandInstruction):
+    pattern = "sbc<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    outputs = ["Rd"]
+    dependsOnFlags = True
+
+
+class sub_shifted(ShiftedOperandInstruction):
+    pattern = "sub<width> <Rd>, <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    outputs = ["Rd"]
+
+
+class teq_shifted(ShiftedOperandInstruction):
+    pattern = "teq<width> <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    modifiesFlags = True
+
+
+class tst_shifted(ShiftedOperandInstruction):
+    pattern = "tst<width> <Rn>, <Rm>, <barrel> <imm>"
+    inputs = ["Rn", "Rm"]
+    modifiesFlags = True
 
 
 class ror(MVEInstruction):

--- a/slothy/targets/arm_v81m/cortex_m55r1.py
+++ b/slothy/targets/arm_v81m/cortex_m55r1.py
@@ -911,6 +911,20 @@ def get_latency(src, out_idx, dst):
     # Check for latency exceptions
     #
 
+    # The shifter source operand needs to be available one cycle earlier.
+    if (
+        instclass_dst
+        in [
+            add_shifted,
+            eor_shifted,
+            orr_shifted,
+            log_and_shifted,
+            bic_shifted,
+        ]
+        and dst.args_in[1] in src.args_out
+    ):
+        return default_latency + 1
+
     # VMULx -> VSTR has single cycle latency
     if instclass_dst in [
         vstrw,

--- a/slothy/targets/arm_v81m/cortex_m55r1.py
+++ b/slothy/targets/arm_v81m/cortex_m55r1.py
@@ -51,16 +51,12 @@ from slothy.targets.arm_v81m.arch_v81m import (
     mvn_imm,
     mov,
     add,
-    add_shifted,
+    ShiftedOperandInstruction,
     log_and,
-    log_and_shifted,
     mul,
     orr,
-    orr_shifted,
     eor,
-    eor_shifted,
     bic,
-    bic_shifted,
     ror,
     ror_imm,
     ror_short,
@@ -385,15 +381,11 @@ execution_units = {
     mov: ExecutionUnit.SCALAR,
     add: ExecutionUnit.SCALAR,
     mul: ExecutionUnit.SCALAR,
-    add_shifted: ExecutionUnit.SCALAR,
+    ShiftedOperandInstruction: ExecutionUnit.SCALAR,
     log_and: ExecutionUnit.SCALAR,
-    log_and_shifted: ExecutionUnit.SCALAR,
     orr: ExecutionUnit.SCALAR,
-    orr_shifted: ExecutionUnit.SCALAR,
     eor: ExecutionUnit.SCALAR,
-    eor_shifted: ExecutionUnit.SCALAR,
     bic: ExecutionUnit.SCALAR,
-    bic_shifted: ExecutionUnit.SCALAR,
     ror: ExecutionUnit.SCALAR,
     ror_imm: ExecutionUnit.SCALAR,
     ror_short: ExecutionUnit.SCALAR,
@@ -552,15 +544,11 @@ inverse_throughput = {
         mvn_imm,
         mov,
         add,
-        add_shifted,
+        ShiftedOperandInstruction,
         log_and,
-        log_and_shifted,
         orr,
-        orr_shifted,
         eor,
-        eor_shifted,
         bic,
-        bic_shifted,
         ror,
         ror_imm,
         ror_short,
@@ -845,13 +833,8 @@ default_latencies = {
         sbfx,
         ubfx,
     ): 1,
-    (
-        add_shifted,
-        eor_shifted,
-        orr_shifted,
-        log_and_shifted,
-        bic_shifted,
-    ): 2,  # NOTE: latency would be 1 if shift amount is 0 in m55
+    # TODO: Model the 1-cycle latency when the shift amount is zero.
+    ShiftedOperandInstruction: 2,
     (vld20, vld21): 2,
     (vld20_with_writeback, vld21_with_writeback): 2,
     (vld40, vld41, vld42, vld43): 2,
@@ -901,6 +884,12 @@ default_latencies = {
 }
 
 
+def _source_registers_at_index(src, out_idx):
+    return [
+        args[out_idx] for args in [src.args_out, src.args_in_out] if out_idx < len(args)
+    ]
+
+
 def get_latency(src, out_idx, dst):
     instclass_src = find_class(src)
     instclass_dst = find_class(dst)
@@ -912,17 +901,9 @@ def get_latency(src, out_idx, dst):
     #
 
     # The shifter source operand needs to be available one cycle earlier.
-    if (
-        instclass_dst
-        in [
-            add_shifted,
-            eor_shifted,
-            orr_shifted,
-            log_and_shifted,
-            bic_shifted,
-        ]
-        and dst.args_in[1] in src.args_out
-    ):
+    if isinstance(
+        dst, ShiftedOperandInstruction
+    ) and dst.shifted_register in _source_registers_at_index(src, out_idx):
         return default_latency + 1
 
     # VMULx -> VSTR has single cycle latency

--- a/slothy/targets/arm_v81m/cortex_m85r1.py
+++ b/slothy/targets/arm_v81m/cortex_m85r1.py
@@ -49,16 +49,12 @@ from slothy.targets.arm_v81m.arch_v81m import (
     mvn_imm,
     mov,
     add,
-    add_shifted,
+    ShiftedOperandInstruction,
     log_and,
-    log_and_shifted,
     mul,
     orr,
-    orr_shifted,
     eor,
-    eor_shifted,
     bic,
-    bic_shifted,
     ror,
     ror_imm,
     ror_short,
@@ -316,16 +312,12 @@ execution_units = {
     mvn_imm: ExecutionUnit.SCALAR,
     mov: ExecutionUnit.SCALAR,
     add: ExecutionUnit.SCALAR,
-    add_shifted: ExecutionUnit.SCALAR,
+    ShiftedOperandInstruction: ExecutionUnit.SCALAR,
     log_and: ExecutionUnit.SCALAR,
-    log_and_shifted: ExecutionUnit.SCALAR,
     mul: ExecutionUnit.SCALAR,
     orr: ExecutionUnit.SCALAR,
-    orr_shifted: ExecutionUnit.SCALAR,
     eor: ExecutionUnit.SCALAR,
-    eor_shifted: ExecutionUnit.SCALAR,
     bic: ExecutionUnit.SCALAR,
-    bic_shifted: ExecutionUnit.SCALAR,
     ror: ExecutionUnit.SCALAR,
     ror_imm: ExecutionUnit.SCALAR,
     ror_short: ExecutionUnit.SCALAR,
@@ -494,15 +486,11 @@ inverse_throughput = {
         mvn_imm,
         mov,
         add,
-        add_shifted,
+        ShiftedOperandInstruction,
         log_and,
-        log_and_shifted,
         orr,
-        orr_shifted,
         eor,
-        eor_shifted,
         bic,
-        bic_shifted,
         ror,
         ror_imm,
         ror_short,
@@ -676,15 +664,11 @@ default_latencies = {
         mvn_imm,
         mov,
         add,
-        add_shifted,
+        ShiftedOperandInstruction,
         log_and,
-        log_and_shifted,
         orr,
-        orr_shifted,
         eor,
-        eor_shifted,
         bic,
-        bic_shifted,
         ror,
         ror_imm,
         ror_short,
@@ -829,6 +813,12 @@ default_latencies = {
 }
 
 
+def _source_registers_at_index(src, out_idx):
+    return [
+        args[out_idx] for args in [src.args_out, src.args_in_out] if out_idx < len(args)
+    ]
+
+
 def get_latency(src, out_idx, dst):
     instclass_src = find_class(src)
     instclass_dst = find_class(dst)
@@ -840,17 +830,9 @@ def get_latency(src, out_idx, dst):
     #
 
     # if inst_src -> inst_dst, the latency from the shifter source operand is 2.
-    if (
-        instclass_dst
-        in [
-            add_shifted,
-            eor_shifted,
-            orr_shifted,
-            log_and_shifted,
-            bic_shifted,
-        ]
-        and dst.args_in[1] in src.args_out
-    ):
+    if isinstance(
+        dst, ShiftedOperandInstruction
+    ) and dst.shifted_register in _source_registers_at_index(src, out_idx):
         return default_latency + 1
 
     # VMULx -> VSTR has single cycle latency

--- a/tests/naive/armv8m/instructions.s
+++ b/tests/naive/armv8m/instructions.s
@@ -440,6 +440,21 @@ cmp r0, r1
 cmp r0, #2
 cmp r7, #0xFF
 
+adc.w r0, r1, r2, lsl #1
+add.w r0, r1, r2, lsl #1
+and.w r0, r1, r2, lsl #1
+bic.w r0, r1, r2, lsl #1
+cmn.w r1, r2, lsl #1
+cmp.w r1, r2, lsl #1
+eor.w r0, r1, r2, lsl #1
+mvn.w r0, r2, lsl #1
+orn.w r0, r1, r2, lsl #1
+orr.w r0, r1, r2, lsl #1
+rsb.w r0, r1, r2, lsl #1
+sbc.w r0, r1, r2, lsl #1
+sub.w r0, r1, r2, lsl #1
+teq.w r1, r2, lsl #1
+tst.w r1, r2, lsl #1
 
 
 ldrb r0, [r0, #16]

--- a/tests/naive/armv8m/test_instruction_model.py
+++ b/tests/naive/armv8m/test_instruction_model.py
@@ -178,6 +178,92 @@ def test_armv7m_width_suffix_and_expression_forms_parse():
     assert insts[2].write() == "eor.w r3, r3, r5"
 
 
+def test_flexible_shifted_operand2_forms_parse_and_round_trip():
+    cases = [
+        ("add.w r0, r1, r2, ror #7", Arch.add_shifted),
+        ("adc.w r0, r1, r2, ror #7", Arch.adc_shifted),
+        ("and.w r0, r1, r2, ror #7", Arch.log_and_shifted),
+        ("orr.w r0, r1, r2, ror #7", Arch.orr_shifted),
+        ("orn.w r0, r1, r2, ror #7", Arch.orn_shifted),
+        ("eor.w r0, r1, r2, ror #7", Arch.eor_shifted),
+        ("bic.w r0, r1, r2, ror #7", Arch.bic_shifted),
+        ("cmn.w r1, r2, ror #7", Arch.cmn_shifted),
+        ("cmp.w r1, r2, ror #7", Arch.cmp_shifted),
+        ("mvn.w r0, r2, ror #7", Arch.mvn_shifted),
+        ("rsb.w r0, r1, r2, ror #7", Arch.rsb_shifted),
+        ("sbc.w r0, r1, r2, ror #7", Arch.sbc_shifted),
+        ("sub.w r0, r1, r2, ror #7", Arch.sub_shifted),
+        ("teq.w r1, r2, ror #7", Arch.teq_shifted),
+        ("tst.w r1, r2, ror #7", Arch.tst_shifted),
+    ]
+
+    for source, expected_class in cases:
+        inst = Arch.Instruction.parser(SourceLine(source))[0]
+        assert type(inst) is expected_class
+        assert isinstance(inst, Arch.ShiftedOperandInstruction)
+        assert inst.shifted_register == "r2"
+        assert inst.width == ".w"
+        assert inst.write() == source
+
+        round_trip = Arch.Instruction.parser(SourceLine(inst.write()))[0]
+        assert type(round_trip) is expected_class
+        assert round_trip.shifted_register == "r2"
+        assert round_trip.width == ".w"
+
+
+def test_flexible_shifted_operand2_flag_semantics():
+    adc = Arch.adc_shifted.make("adc.w r0, r1, r2, lsl #3")
+    sbc = Arch.sbc_shifted.make("sbc.w r0, r1, r2, lsr #3")
+
+    for inst in [adc, sbc]:
+        assert inst.args_in == ["r1", "r2", "flags"]
+        assert inst.arg_types_in == [
+            Arch.RegisterType.GPR,
+            Arch.RegisterType.GPR,
+            Arch.RegisterType.FLAGS,
+        ]
+        assert inst.args_out == ["r0"]
+        assert inst.shifted_register == "r2"
+
+    for instruction_class, mnemonic in [
+        (Arch.cmn_shifted, "cmn"),
+        (Arch.cmp_shifted, "cmp"),
+        (Arch.teq_shifted, "teq"),
+        (Arch.tst_shifted, "tst"),
+    ]:
+        inst = instruction_class.make(f"{mnemonic}.w r1, r2, asr #3")
+        assert inst.args_in == ["r1", "r2"]
+        assert inst.args_out == ["flags"]
+        assert inst.arg_types_out == [Arch.RegisterType.FLAGS]
+        assert inst.shifted_register == "r2"
+
+    mvn = Arch.mvn_shifted.make("mvn.w r0, r2, ror #3")
+    assert mvn.args_in == ["r2"]
+    assert mvn.args_out == ["r0"]
+    assert mvn.shifted_register == "r2"
+
+
+def test_shifted_adc_and_sbc_consume_without_replacing_flags():
+    graph = _graph(
+        """
+        cmp r7, r8
+        adc.w r0, r1, r2, lsl #3
+        sbc.w r3, r4, r5, lsr #3
+        """,
+        outputs=["r0", "r3"],
+        allow_useless=False,
+    )
+
+    compare, adc, sbc = graph.nodes
+    assert adc.src_in[2].src is compare
+    assert sbc.src_in[2].src is compare
+
+
+def test_pkhbt_is_not_a_flexible_operand2_instruction():
+    inst = Arch.pkhbt_shifted.make("pkhbt r0, r1, r2, lsl #16")
+    assert not isinstance(inst, Arch.ShiftedOperandInstruction)
+
+
 def run_instruction_model_tests():
     test_adjacent_vmov_pair_rewrites_first_only()
     test_vmov_pair_rewrites_across_intervening_unrelated_instruction()
@@ -187,6 +273,10 @@ def run_instruction_model_tests():
     test_flags_can_be_declared_as_region_output()
     test_issue_419_reproducer_forms_parse()
     test_armv7m_width_suffix_and_expression_forms_parse()
+    test_flexible_shifted_operand2_forms_parse_and_round_trip()
+    test_flexible_shifted_operand2_flag_semantics()
+    test_shifted_adc_and_sbc_consume_without_replacing_flags()
+    test_pkhbt_is_not_a_flexible_operand2_instruction()
 
 
 if __name__ == "__main__":

--- a/tests/naive/armv8m/test_memory_model.py
+++ b/tests/naive/armv8m/test_memory_model.py
@@ -26,8 +26,20 @@
 from dataclasses import dataclass
 from types import SimpleNamespace
 
-from slothy.targets.arm_v81m.arch_v81m import eor, ldr, ldrd, qrestore, qsave
-from slothy.targets.arm_v81m.arch_v81m import str_reg, strd
+from slothy.targets.arm_v81m.arch_v81m import (
+    add_shifted,
+    bic_shifted,
+    eor,
+    eor_shifted,
+    ldr,
+    ldrd,
+    log_and_shifted,
+    orr_shifted,
+    qrestore,
+    qsave,
+    str_reg,
+    strd,
+)
 from slothy.targets.arm_v81m.cortex_m55r1 import (
     ExecutionUnit,
     add_further_constraints,
@@ -184,6 +196,34 @@ def test_scalar_str_model():
     assert get_latency(inst, 0, _consumer()) == 1
 
 
+def test_shifted_source_operand_needs_extra_cycle():
+    producer = eor.make("eor r1, r2, r3")
+    shifted_consumers = [
+        add_shifted.make("add r4, r5, r1, ror #13"),
+        eor_shifted.make("eor r4, r5, r1, ror #13"),
+        orr_shifted.make("orr r4, r5, r1, ror #13"),
+        log_and_shifted.make("and r4, r5, r1, ror #13"),
+        bic_shifted.make("bic r4, r5, r1, ror #13"),
+    ]
+
+    for consumer in shifted_consumers:
+        assert get_latency(producer, 0, consumer) == 2
+
+
+def test_unshifted_source_operand_keeps_default_latency():
+    producer = eor.make("eor r1, r2, r3")
+    unshifted_consumers = [
+        add_shifted.make("add r4, r1, r5, ror #13"),
+        eor_shifted.make("eor r4, r1, r5, ror #13"),
+        orr_shifted.make("orr r4, r1, r5, ror #13"),
+        log_and_shifted.make("and r4, r1, r5, ror #13"),
+        bic_shifted.make("bic r4, r1, r5, ror #13"),
+    ]
+
+    for consumer in unshifted_consumers:
+        assert get_latency(producer, 0, consumer) == 1
+
+
 def test_dtcm_bank_uses_address_bits_3_2():
     assert m55_dtcm_bank(0) == 0
     assert m55_dtcm_bank(4) == 1
@@ -247,6 +287,8 @@ def run_memory_model_tests():
     test_ldrd_model()
     test_strd_model()
     test_scalar_str_model()
+    test_shifted_source_operand_needs_extra_cycle()
+    test_unshifted_source_operand_keeps_default_latency()
     test_dtcm_bank_uses_address_bits_3_2()
     test_same_base_same_bank_scalar_str_ldr_adds_forbidden_distance()
     test_same_base_different_bank_scalar_str_ldr_has_no_model_hazard()

--- a/tests/naive/armv8m/test_memory_model.py
+++ b/tests/naive/armv8m/test_memory_model.py
@@ -27,18 +27,30 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 
 from slothy.targets.arm_v81m.arch_v81m import (
+    adc_shifted,
     add_shifted,
     bic_shifted,
+    cmn_shifted,
+    cmp_reg,
+    cmp_shifted,
     eor,
     eor_shifted,
     ldr,
     ldrd,
     log_and_shifted,
+    mvn_shifted,
+    orn_shifted,
     orr_shifted,
     qrestore,
     qsave,
+    ror_short,
+    rsb_shifted,
+    sbc_shifted,
     str_reg,
     strd,
+    sub_shifted,
+    teq_shifted,
+    tst_shifted,
 )
 from slothy.targets.arm_v81m.cortex_m55r1 import (
     ExecutionUnit,
@@ -145,6 +157,33 @@ def _consumer():
     return eor.make("eor r4, r5, r6")
 
 
+_SHIFTED_CONSUMER_FORMS = [
+    (adc_shifted, "adc r4, {rn}, {rm}, ror #13"),
+    (add_shifted, "add r4, {rn}, {rm}, ror #13"),
+    (log_and_shifted, "and r4, {rn}, {rm}, ror #13"),
+    (bic_shifted, "bic r4, {rn}, {rm}, ror #13"),
+    (cmn_shifted, "cmn {rn}, {rm}, ror #13"),
+    (cmp_shifted, "cmp {rn}, {rm}, ror #13"),
+    (eor_shifted, "eor r4, {rn}, {rm}, ror #13"),
+    (mvn_shifted, "mvn r4, {rm}, ror #13"),
+    (orn_shifted, "orn r4, {rn}, {rm}, ror #13"),
+    (orr_shifted, "orr r4, {rn}, {rm}, ror #13"),
+    (rsb_shifted, "rsb r4, {rn}, {rm}, ror #13"),
+    (sbc_shifted, "sbc r4, {rn}, {rm}, ror #13"),
+    (sub_shifted, "sub r4, {rn}, {rm}, ror #13"),
+    (teq_shifted, "teq {rn}, {rm}, ror #13"),
+    (tst_shifted, "tst {rn}, {rm}, ror #13"),
+]
+
+
+def _shifted_consumers(rn="r5", rm="r1", include_unary=True):
+    return [
+        instruction_class.make(form.format(rn=rn, rm=rm))
+        for instruction_class, form in _SHIFTED_CONSUMER_FORMS
+        if include_unary or "{rn}" in form
+    ]
+
+
 def _scalar_str_ldr_pair(base, store_imm=0, load_imm=16):
     parse_base = "r13" if base == "sp" else base
     store = str_reg.make(f"str r2, [{parse_base}, #{store_imm}]")
@@ -196,31 +235,50 @@ def test_scalar_str_model():
     assert get_latency(inst, 0, _consumer()) == 1
 
 
+def test_shifted_operand_instruction_model():
+    for instruction in _shifted_consumers():
+        assert get_units(instruction) == [ExecutionUnit.SCALAR]
+        assert get_inverse_throughput(instruction) == 1
+        assert get_latency(instruction, 0, _consumer()) == 2
+
+
 def test_shifted_source_operand_needs_extra_cycle():
     producer = eor.make("eor r1, r2, r3")
-    shifted_consumers = [
-        add_shifted.make("add r4, r5, r1, ror #13"),
-        eor_shifted.make("eor r4, r5, r1, ror #13"),
-        orr_shifted.make("orr r4, r5, r1, ror #13"),
-        log_and_shifted.make("and r4, r5, r1, ror #13"),
-        bic_shifted.make("bic r4, r5, r1, ror #13"),
-    ]
 
-    for consumer in shifted_consumers:
+    for consumer in _shifted_consumers():
         assert get_latency(producer, 0, consumer) == 2
 
 
 def test_unshifted_source_operand_keeps_default_latency():
     producer = eor.make("eor r1, r2, r3")
-    unshifted_consumers = [
-        add_shifted.make("add r4, r1, r5, ror #13"),
-        eor_shifted.make("eor r4, r1, r5, ror #13"),
-        orr_shifted.make("orr r4, r1, r5, ror #13"),
-        log_and_shifted.make("and r4, r1, r5, ror #13"),
-        bic_shifted.make("bic r4, r1, r5, ror #13"),
+
+    for consumer in _shifted_consumers(rn="r1", rm="r5", include_unary=False):
+        assert get_latency(producer, 0, consumer) == 1
+
+
+def test_shifted_latency_uses_the_selected_producer_output():
+    producer = ldrd.make("ldrd r0, r1, [r2, #16]")
+    consumer = eor_shifted.make("eor r4, r5, r1, ror #13")
+
+    assert get_latency(producer, 0, consumer) == 2
+    assert get_latency(producer, 1, consumer) == 3
+
+
+def test_in_out_producer_feeding_shifted_source_gets_extra_cycle():
+    producer = ror_short.make("ror r1, #10")
+    consumer = eor_shifted.make("eor r4, r5, r1, ror #13")
+
+    assert get_latency(producer, 0, consumer) == 2
+
+
+def test_flag_dependency_is_not_treated_as_shifted_register_dependency():
+    producer = cmp_reg.make("cmp r0, r1")
+    consumers = [
+        adc_shifted.make("adc r4, r5, r6, ror #13"),
+        sbc_shifted.make("sbc r4, r5, r6, ror #13"),
     ]
 
-    for consumer in unshifted_consumers:
+    for consumer in consumers:
         assert get_latency(producer, 0, consumer) == 1
 
 
@@ -287,8 +345,12 @@ def run_memory_model_tests():
     test_ldrd_model()
     test_strd_model()
     test_scalar_str_model()
+    test_shifted_operand_instruction_model()
     test_shifted_source_operand_needs_extra_cycle()
     test_unshifted_source_operand_keeps_default_latency()
+    test_shifted_latency_uses_the_selected_producer_output()
+    test_in_out_producer_feeding_shifted_source_gets_extra_cycle()
+    test_flag_dependency_is_not_treated_as_shifted_register_dependency()
     test_dtcm_bank_uses_address_bits_3_2()
     test_same_base_same_bank_scalar_str_ldr_adds_forbidden_distance()
     test_same_base_different_bank_scalar_str_ldr_has_no_model_hazard()


### PR DESCRIPTION
Fixes #463

## Summary

Model the additional Cortex-M55 latency when a producer feeds the flexible
shifted-register Operand2 (`Rm`) of scalar instructions.

The model now covers all flexible Operand2 instruction families documented in
the Cortex-M55 Software Optimization Guide:

- ADC
- ADD
- AND
- BIC
- CMN
- CMP
- EOR
- MVN
- ORN
- ORR
- RSB
- SBC
- SUB
- TEQ
- TST

The latency remains unchanged when the producer feeds the unshifted operand.
PKHBT/PKHTB remain separate because they are fixed-latency packing
instructions, not flexible Operand2 forms.

A shared `ShiftedOperandInstruction` base class provides consistent parsing and
operand identification. The M55 and M85 target models use operand-aware
dependency matching, including multi-output and input/output producers.
Carry-flag and comparison/test flag semantics are covered explicitly.

## Motivation

The previous implementation modeled only ADD, EOR, ORR, AND, and BIC because
those were sufficient for the Keccak scheduling workload. The instruction-set
reference defines the shifted Operand2 form more broadly, so the model should
represent the full instruction family rather than a workload-specific subset.

## Performance evidence

The historical Keccak measurements motivating this change remain:

| Schedule | Cycles | Delta vs M7 |
| --- | ---: | ---: |
| M7 schedule | 9851 | — |
| M55 schedule with shifted-source latency | 9502 | -349 |

The Keccak input uses only the already-supported EOR and BIC shifted forms, so
the generalized model produces the same Keccak dependency latencies as the
previous implementation. New hardware measurements are not included in this
model-expansion PR.

## Testing

- Armv8-M instruction-model and memory-model tests
- M55 and M85 target test suites with `-W error`
- M55 and M85 example dry-runs
- `flake8 .`
- `black --check --diff .`
- `git diff --check`